### PR TITLE
stress-ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # benchmark-containers
-Benchmark container build files for a variety of cloud-native benchmarks.
+Benchmark container build files for a variety of cloud-native system-level
+benchmarks.
 
 fio
 ===
 The FIO container ships release 3.15 of the
 [Flexible IO tester](https://github.com/axboe/fio), and also contains version
 0.8.0 of [dstat](https://github.com/dagwieers/dstat).
+The container is based on Alpine, to optimize for image size.
+
+stress-ng
+=========
+The container ships release 0.10.07 of
+[stress-ng](https://github.com/ColinIanKing/stress-ng), and also contains
+version 0.8.0 of [dstat](https://github.com/dagwieers/dstat).
 The container is based on Alpine, to optimize for image size.

--- a/stress-ng/Dockerfile
+++ b/stress-ng/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:buster as builder
+
+# intall gcc and supporting packages
+RUN apt-get update && apt-get install -yq make gcc build-essential git gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-8-aarch64-linux-gnu
+
+WORKDIR /code
+
+# download stress-ng sources
+ENV STRESS_VER=0.09.41
+ADD https://github.com/ColinIanKing/stress-ng/archive/V${STRESS_VER}.tar.gz .
+RUN tar -xf V${STRESS_VER}.tar.gz && mv stress-ng-${STRESS_VER} stress-ng
+
+# make static version
+WORKDIR /code/stress-ng
+RUN CC=aarch64-linux-gnu-gcc-8 STATIC=1 make
+
+# Final image
+FROM scratch
+
+COPY --from=builder /code/stress-ng/stress-ng /
+
+USER nobody
+
+ENTRYPOINT ["/stress-ng"]

--- a/stress-ng/Dockerfile
+++ b/stress-ng/Dockerfile
@@ -1,24 +1,34 @@
-FROM debian:buster as builder
+FROM alpine as builder
+MAINTAINER Kinvolk
 
 # intall gcc and supporting packages
-RUN apt-get update && apt-get install -yq make gcc build-essential git gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-8-aarch64-linux-gnu
+RUN apk add --update alpine-sdk git linux-headers
 
 WORKDIR /code
 
 # download stress-ng sources
-ENV STRESS_VER=0.09.41
+ENV STRESS_VER=0.10.07
 ADD https://github.com/ColinIanKing/stress-ng/archive/V${STRESS_VER}.tar.gz .
 RUN tar -xf V${STRESS_VER}.tar.gz && mv stress-ng-${STRESS_VER} stress-ng
 
 # make static version
 WORKDIR /code/stress-ng
-RUN CC=aarch64-linux-gnu-gcc-8 STATIC=1 make
+RUN STATIC=1 make -j
+
+# add dstat
+RUN cd / && git clone https://github.com/dagwieers/dstat.git
+COPY ./dstat-types.patch /dstat/dstat-types.patch
+RUN cd /dstat && \
+    patch <dstat-types.patch
 
 # Final image
-FROM scratch
+FROM alpine
+MAINTAINER Kinvolk
 
-COPY --from=builder /code/stress-ng/stress-ng /
+RUN apk add --update --no-cache py2-six
+COPY --from=builder /code/stress-ng/stress-ng /sbin/
+COPY --from=builder /dstat/dstat /usr/local/bin/
+COPY --from=builder /dstat/plugins /usr/local/bin/
 
 USER nobody
-
-ENTRYPOINT ["/stress-ng"]
+WORKDIR /tmp

--- a/stress-ng/dstat-types.patch
+++ b/stress-ng/dstat-types.patch
@@ -1,0 +1,12 @@
+diff --git a/dstat b/dstat
+index 9359965..0f9c98b 100755
+--- dstat
++++ dstat
+@@ -32,6 +32,7 @@ import sched
+ import six
+ import sys
+ import time
++import types
+ 
+ VERSION = '0.8.0'
+

--- a/stress-ng/stress-ng.yaml
+++ b/stress-ng/stress-ng.yaml
@@ -19,6 +19,8 @@ spec:
       containers:
       - name: stress-ng
         image: quay.io/kinvolk/stress-ng:latest-arm64
+        command:
+        - stress-ng
         args:
         - --cpu
         - "4"

--- a/stress-ng/stress-ng.yaml
+++ b/stress-ng/stress-ng.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-arm
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stress-ng
+  namespace: benchmark-arm
+spec:
+  template:
+    metadata:
+      labels:
+        app: stress-ng
+    spec:
+      securityContext:
+        runAsUser: 65534
+      containers:
+      - name: stress-ng
+        image: quay.io/kinvolk/stress-ng:latest-arm64
+        args:
+        - --cpu
+        - "4"
+        - --io
+        - "2"
+        - --vm
+        - "1"
+        - --vm-bytes
+        - "1G"
+        - --timeout
+        - "60s"
+        - --metrics-brief
+      restartPolicy: Never


### PR DESCRIPTION
This PR adds stress-ng, the image is based on alpine.
The container also includes dstat (same as in the fio container).

The PR is mostly based on @dongsupark 's work with a few minor modifications.

<details><summary>Testing done:</summary>
*build*
<pre>
$ docker build -t stress-ng .

Sending build context to Docker daemon   89.6kB

Step 1/20 : FROM alpine as builder
latest: Pulling from library/alpine
29bddadc8f3f: Already exists
Digest: sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb
Status: Downloaded newer image for alpine:latest
 ---> 915beeae4675
Step 2/20 : MAINTAINER Kinvolk
 ---> Running in 4894693de78f
Removing intermediate container 4894693de78f
 ---> c497b8e9fbe5
Step 3/20 : RUN apk add --update alpine-sdk git linux-headers
 ---> Running in 71a447498ed0
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/aarch64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/aarch64/APKINDEX.tar.gz
(1/39) Installing fakeroot (1.23-r0)
(2/39) Installing sudo (1.8.27-r0)
(3/39) Installing libcap (2.27-r0)
(4/39) Installing pax-utils (1.2.3-r0)
(5/39) Installing openssl (1.1.1d-r0)
(6/39) Installing libattr (2.4.48-r0)
(7/39) Installing attr (2.4.48-r0)
(8/39) Installing tar (1.32-r0)
(9/39) Installing pkgconf (1.6.1-r1)
(10/39) Installing patch (2.7.6-r6)
(11/39) Installing libgcc (8.3.0-r0)
(12/39) Installing libstdc++ (8.3.0-r0)
(13/39) Installing lzip (1.21-r0)
(14/39) Installing ca-certificates (20190108-r0)
(15/39) Installing nghttp2-libs (1.39.2-r0)
(16/39) Installing libcurl (7.66.0-r0)
(17/39) Installing curl (7.66.0-r0)
(18/39) Installing abuild (3.4.0-r0)
Executing abuild-3.4.0-r0.pre-install
(19/39) Installing binutils (2.32-r0)
(20/39) Installing libmagic (5.37-r0)
(21/39) Installing file (5.37-r0)
(22/39) Installing gmp (6.1.2-r1)
(23/39) Installing isl (0.18-r0)
(24/39) Installing libgomp (8.3.0-r0)
(25/39) Installing libatomic (8.3.0-r0)
(26/39) Installing mpfr3 (3.1.5-r1)
(27/39) Installing mpc1 (1.1.0-r0)
(28/39) Installing gcc (8.3.0-r0)
(29/39) Installing musl-dev (1.1.22-r3)
(30/39) Installing libc-dev (0.7.1-r0)
(31/39) Installing g++ (8.3.0-r0)
(32/39) Installing make (4.2.1-r2)
(33/39) Installing fortify-headers (1.1-r0)
(34/39) Installing build-base (0.5-r1)
(35/39) Installing expat (2.2.8-r0)
(36/39) Installing pcre2 (10.33-r0)
(37/39) Installing git (2.22.0-r0)
(38/39) Installing alpine-sdk (1.0-r0)
(39/39) Installing linux-headers (4.19.36-r0)
Executing busybox-1.30.1-r2.trigger
Executing ca-certificates-20190108-r0.trigger
OK: 186 MiB in 53 packages
Removing intermediate container 71a447498ed0
 ---> 25d441477b0d
Step 4/20 : WORKDIR /code
 ---> Running in 4e9d2be459e5
Removing intermediate container 4e9d2be459e5
 ---> a560a431e27b
Step 5/20 : ENV STRESS_VER=0.10.07
 ---> Running in a45130b036bb
Removing intermediate container a45130b036bb
 ---> c79e80121231
Step 6/20 : ADD https://github.com/ColinIanKing/stress-ng/archive/V${STRESS_VER}.tar.gz .

 ---> 4be47b6cd4c9
Step 7/20 : RUN tar -xf V${STRESS_VER}.tar.gz && mv stress-ng-${STRESS_VER} stress-ng
 ---> Running in ce69e88b804c
Removing intermediate container ce69e88b804c
 ---> 985da6a586a9
Step 8/20 : WORKDIR /code/stress-ng
 ---> Running in 4d5cbeec47c0
Removing intermediate container 4d5cbeec47c0
 ---> 1a5387b4495e
Step 9/20 : RUN STATIC=1 make -j
 ---> Running in f5c2cd0766bd
make makeconfig
make[1]: Entering directory '/code/stress-ng'
make[2]: Entering directory '/code/stress-ng'
autoconfig: using -lcrypt
autoconfig: using -lrt
autoconfig: using -lpthread spinlock
autoconfig: using -lpthread
autoconfig: using aio.h
autoconfig: using complex.h
autoconfig: using wchar.h
autoconfig: using crypt.h
autoconfig: using features.h
autoconfig: using fenv.h
autoconfig: using float.h
autoconfig: using grp.h
autoconfig: using libgen.h
autoconfig: using link.h
autoconfig: using locale.h
autoconfig: using malloc.h
autoconfig: using mntent.h
autoconfig: using mqueue.h
autoconfig: using poll.h
autoconfig: using semaphore.h
autoconfig: using strings.h
autoconfig: using syslog.h
autoconfig: using spawn.h
autoconfig: using termios.h
autoconfig: using ucontext.h
autoconfig: using utime.h
autoconfig: using net/if.h
autoconfig: using netinet/ip.h
autoconfig: using netinet/ip_icmp.h
autoconfig: using netinet/tcp.h
autoconfig: using sys/auxv.h
autoconfig: using sys/epoll.h
autoconfig: using sys/eventfd.h
autoconfig: using sys/inotify.h
autoconfig: using sys/io.h
autoconfig: using sys/ipc.h
autoconfig: using sys/fanotify.h
autoconfig: using sys/mount.h
autoconfig: using sys/msg.h
autoconfig: using sys/param.h
autoconfig: using sys/personality.h
autoconfig: using sys/prctl.h
autoconfig: using sys/quota.h
autoconfig: using sys/select.h
autoconfig: using sys/sendfile.h
autoconfig: using sys/shm.h
autoconfig: using sys/signalfd.h
autoconfig: using sys/statfs.h
autoconfig: using sys/statvfs.h
autoconfig: using sys/swap.h
autoconfig: using sys/syscall.h
autoconfig: using sys/sysinfo.h
autoconfig: using sys/sysmacros.h
autoconfig: using sys/timerfd.h
autoconfig: using sys/timex.h
autoconfig: using sys/uio.h
autoconfig: using sys/un.h
autoconfig: using sys/utsname.h
autoconfig: using sys/vfs.h
autoconfig: using sys/xattr.h
autoconfig: using linux/audit.h
autoconfig: using linux/cn_proc.h
autoconfig: using linux/connector.h
autoconfig: using linux/dm-ioctl.h
autoconfig: using linux/if_alg.h
autoconfig: using linux/fiemap.h
autoconfig: using linux/filter.h
autoconfig: using linux/futex.h
autoconfig: using linux/fs.h
autoconfig: using linux/genetlink.h
autoconfig: using linux/hdreg.h
autoconfig: using linux/hpet.h
autoconfig: using linux/loop.h
autoconfig: using linux/media.h
autoconfig: using linux/membarrier.h
autoconfig: using linux/netlink.h
autoconfig: using linux/perf_event.h
autoconfig: using linux/posix_types.h
autoconfig: using linux/random.h
autoconfig: using linux/rtc.h
autoconfig: using linux/rtnetlink.h
autoconfig: using linux/seccomp.h
autoconfig: using linux/sock_diag.h
autoconfig: using linux/socket.h
autoconfig: using linux/sysctl.h
autoconfig: using linux/taskstats.h
autoconfig: using linux/unix_diag.h
autoconfig: using linux/userfaultfd.h.h
autoconfig: using linux/version.h
autoconfig: using linux/videodev2.h
autoconfig: using linux/vt.h
autoconfig: using linux/watchdog.h
autoconfig: using scsi/scsi.h
autoconfig: using scsi/sg.h
autoconfig: using float16 support
autoconfig: using float32 support
autoconfig: using int128_t support
autoconfig: using vector math support
autoconfig: using atomic support
autoconfig: using nop assembler instruction
autoconfig: using 64 byte alignment attribute
autoconfig: using 128 byte alignment attribute
autoconfig: using 64K byte alignment attribute
autoconfig: using accept4
autoconfig: using adjtime
autoconfig: using adjtimex
autoconfig: using affinity scheduling CPU masks
autoconfig: using brk
autoconfig: using __builtin_ctz
autoconfig: using __builtin_memcpy
autoconfig: using __builtin_memmove
autoconfig: using __builtin_prefetch
autoconfig: using cabsl
autoconfig: using ccosl
autoconfig: using chroot
autoconfig: using crypt_r
autoconfig: using clearenv
autoconfig: using clock_getres
autoconfig: using clock_gettime
autoconfig: using clock_nanosleep
autoconfig: using clock_settime
autoconfig: using clone
autoconfig: using complex
autoconfig: using coshl
autoconfig: using cosl
autoconfig: using cpow
autoconfig: using csinl
autoconfig: using dup3
autoconfig: using epoll_create1
autoconfig: using eventfd
autoconfig: using execveat
autoconfig: using expl
autoconfig: using faccessat
autoconfig: using fallocate
autoconfig: using fanotify
autoconfig: using fchownat
autoconfig: using fdatasync
autoconfig: using fgetxattr
autoconfig: using flistxattr
autoconfig: using flock
autoconfig: using fremovexattr
autoconfig: using fsetxattr
autoconfig: using fsync
autoconfig: using futimens
autoconfig: using futimes
autoconfig: using getauxval
autoconfig: using getdtablesize
autoconfig: using getmntent
autoconfig: using getpagesize
autoconfig: using getpgid
autoconfig: using getpriority
autoconfig: using getresgid
autoconfig: using getresuid
autoconfig: using getsid
autoconfig: using getxattr
autoconfig: using ino64_t
autoconfig: using inotify
autoconfig: using __kernel_long_t
autoconfig: using __kernel_ulong_t
autoconfig: using label as value feature
autoconfig: using lgammal
autoconfig: using lgetxattr
autoconfig: using listxattr
autoconfig: using lockf
autoconfig: using logl
autoconfig: using lookup_dcookie
autoconfig: using lsetxattr
autoconfig: using madvise
autoconfig: using memfd_create
autoconfig: using mincore
autoconfig: using mlock
autoconfig: using mlock2
autoconfig: using mlockall and munlockall
autoconfig: using mprotect
autoconfig: using mremap
autoconfig: using msync
autoconfig: using munlock
autoconfig: using name_to_handle_at
autoconfig: using nanosleep
autoconfig: using nice
autoconfig: using off64_t
autoconfig: using open_by_handle_at
autoconfig: using personality
autoconfig: using pipe2
autoconfig: using pkey_alloc
autoconfig: using pkey_free
autoconfig: using pkey_mprotect
autoconfig: using posix_fadvise
autoconfig: using posix_fallocate
autoconfig: using posix_madvise
autoconfig: using posix_memalign
autoconfig: using posix_openpt
autoconfig: using POSIX semaphores
autoconfig: using posix_spawn
autoconfig: using powl
autoconfig: using ppoll
autoconfig: using prctl
autoconfig: using prlimit
autoconfig: using process_vm_readv
autoconfig: using process_vm_writev
autoconfig: using pselect
autoconfig: using ptrace
autoconfig: using ptsname
autoconfig: using pwritev
autoconfig: using remap_file_pages
autoconfig: using renameat
autoconfig: using rintl
autoconfig: using sched_get_priority_max
autoconfig: using sched_get_priority_min
autoconfig: using sched_getaffinity
autoconfig: using sched_getcpu
autoconfig: using sched_rr_get_interval
autoconfig: using sched_setscheduler
autoconfig: using sched_yield
autoconfig: using sendmmsg
autoconfig: using setns
autoconfig: using setpgid
autoconfig: using setpgrp
autoconfig: using setpriority
autoconfig: using setregid
autoconfig: using setresgid
autoconfig: using setresuid
autoconfig: using setreuid
autoconfig: using setxattr
autoconfig: using sigaltstack
autoconfig: using sigqueue
autoconfig: using sigwaitinfo
autoconfig: using sinhl
autoconfig: using sinl
autoconfig: using splice
autoconfig: using sqrtl
autoconfig: using statfs
autoconfig: using struct iphdr and icmphdr
autoconfig: using struct msginfo
autoconfig: using struct shmid_ds
autoconfig: using struct shminfo
autoconfig: using swapon and swapoff
autoconfig: using sync_file_range
autoconfig: using syncfs
autoconfig: using sysinfo
autoconfig: using SYSV message queues
autoconfig: using SYSV semaphores
autoconfig: using SYSV semtimedop
autoconfig: using SYSV shared memory
autoconfig: using tee
autoconfig: using timer_create
autoconfig: using timer_delete
autoconfig: using timer_gettime
autoconfig: using timer_getoverrrun
autoconfig: using timer_settime
autoconfig: using ttyname
autoconfig: using uname
autoconfig: using unshare
autoconfig: using utimensat
autoconfig: using variable length array function args
autoconfig: using vmsplice
autoconfig: using waitid
make[2]: Leaving directory '/code/stress-ng'
make[1]: Leaving directory '/code/stress-ng'
make stress-ng
make[1]: Entering directory '/code/stress-ng'
CC stress-access.c
CC stress-affinity.c
CC stress-af-alg.c
CC stress-aio.c
CC stress-aio-linux.c
CC stress-apparmor.c
CC stress-atomic.c
CC stress-bad-altstack.c
CC stress-bigheap.c
CC stress-bind-mount.c
CC stress-branch.c
CC stress-brk.c
CC stress-bsearch.c
CC stress-cache.c
CC stress-cap.c
CC stress-chdir.c
CC stress-chown.c
CC stress-chmod.c
CC stress-close.c
CC stress-clock.c
CC stress-chroot.c
CC stress-clone.c
CC stress-context.c
CC stress-dccp.c
CC stress-dentry.c
CC stress-cpu.c
CC stress-cpu-online.c
CC stress-crypt.c
CC stress-copy-file.c
CC stress-daemon.c
CC stress-dev-shm.c
CC stress-dev.c
CC stress-dirdeep.c
CC stress-dnotify.c
CC stress-dup.c
CC stress-enosys.c
CC stress-cyclic.c
CC stress-eventfd.c
CC stress-dynlib.c
CC stress-exec.c
CC stress-fallocate.c
CC stress-fault.c
CC stress-epoll.c
CC stress-efivar.c
CC stress-fanotify.c
CC stress-dir.c
CC stress-fcntl.c
CC stress-fork.c
CC stress-file-ioctl.c
CC stress-funccall.c
CC stress-fiemap.c
CC stress-fp-error.c
CC stress-icmp-flood.c
CC stress-getdent.c
CC stress-heapsort.c
CC stress-fstat.c
CC stress-filename.c
CC stress-ipsec-mb.c
CC stress-funcret.c
CC stress-hrtimers.c
CC stress-flock.c
CC stress-full.c
CC stress-get.c
CC stress-fifo.c
CC stress-getrandom.c
CC stress-ioport.c
CC stress-inotify.c
CC stress-icache.c
CC stress-idle-page.c
CC stress-futex.c
CC stress-inode-flags.c
CC stress-locka.c
CC stress-klog.c
CC stress-link.c
CC stress-lockofd.c
CC stress-kcmp.c
CC stress-matrix.c
CC stress-ioprio.c
CC stress-lockbus.c
CC stress-lockf.c
CC stress-hdd.c
CC stress-iosync.c
CC stress-key.c
CC stress-lsearch.c
CC stress-kill.c
CC stress-iomix.c
CC stress-memthrash.c
CC stress-madvise.c
CC stress-mcontend.c
CC stress-itimer.c
CC stress-loop.c
CC stress-malloc.c
CC stress-matrix-3d.c
CC stress-mknod.c
CC stress-membarrier.c
CC stress-memfd.c
CC stress-memcpy.c
CC stress-mlockmany.c
CC stress-memrate.c
CC stress-mergesort.c
CC stress-longjmp.c
CC stress-mlock.c
CC stress-handle.c
CC stress-mincore.c
CC stress-mmapfixed.c
CC stress-mmapfork.c
CC stress-mmapmany.c
CC stress-mmap.c
CC stress-mmapaddr.c
CC stress-hsearch.c
CC stress-lease.c
CC stress-mremap.c
CC stress-pkey.c
CC stress-msync.c
CC stress-msg.c
CC stress-netlink-proc.c
CC stress-mq.c
CC stress-opcode.c
CC stress-netlink-task.c
CC stress-netdev.c
CC stress-nop.c
CC stress-pidfd.c
CC stress-numa.c
CC stress-open.c
CC stress-prctl.c
CC stress-physpage.c
CC stress-pty.c
CC stress-qsort.c
CC stress-ramfs.c
CC stress-null.c
CC stress-pthread.c
CC stress-procfs.c
CC stress-ptrace.c
CC stress-nice.c
CC stress-pipe.c
CC stress-poll.c
CC stress-oom-pipe.c
CC stress-quota.c
CC stress-radixsort.c
CC stress-rawdev.c
CC stress-rdrand.c
CC stress-remap-file-pages.c
CC stress-rawsock.c
CC stress-readahead.c
CC stress-schedpolicy.c
CC stress-sctp.c
CC stress-rmap.c
CC stress-rlimit.c
CC stress-seal.c
CC stress-rename.c
CC stress-rtc.c
CC stress-seccomp.c
CC stress-resources.c
CC stress-revio.c
CC stress-seek.c
CC stress-sem.c
CC stress-sem-sysv.c
CC stress-set.c
CC stress-shm-sysv.c
CC stress-sigfd.c
CC stress-sigrt.c
CC stress-socketpair.c
CC stress-socket-diag.c
CC stress-shm.c
CC stress-splice.c
CC stress-sigq.c
CC stress-shellsort.c
CC stress-sleep.c
CC stress-sigio.c
CC stress-sigfpe.c
CC stress-sysinfo.c
CC stress-stream.c
CC stress-sysfs.c
CC stress-stack.c
CC stress-timer.c
CC stress-sendfile.c
CC stress-sigpending.c
CC stress-socket.c
CC stress-socket-fd.c
CC stress-swap.c
CC stress-tee.c
CC stress-spawn.c
CC stress-sigsuspend.c
CC stress-sigsegv.c
CC stress-sync-file.c
CC stress-tlb-shootdown.c
CC stress-switch.c
CC stress-str.c
CC stress-sysbadaddr.c
CC stress-timerfd.c
CC stress-stackmmap.c
CC stress-sigpipe.c
CC stress-softlockup.c
CC stress-udp.c
CC stress-udp-flood.c
CC stress-unshare.c
CC stress-tmpfs.c
CC stress-urandom.c
CC stress-tsc.c
CC stress-tsearch.c
CC stress-vm-segv.c
CC stress-xattr.c
CC stress-vm-addr.c
CC stress-utime.c
CC stress-vdso.c
CC stress-tree.c
CC stress-userfaultfd.c
CC stress-vecmath.c
CC stress-vm-rw.c
CC stress-vm.c
CC stress-yield.c
CC stress-watchdog.c
CC core-affinity.c
CC stress-vforkmany.c
CC stress-vm-splice.c
CC stress-wait.c
CC stress-wcstr.c
CC stress-zombie.c
CC core-cpu.c
CC stress-zero.c
CC core-cache.c
CC stress-zlib.c
CC core-log.c
CC core-io-priority.c
CC core-job.c
CC core-ignite-cpu.c
CC core-net.c
CC core-mwc.c
CC core-thermal-zone.c
CC core-mlock.c
CC core-mmap.c
CC core-sched.c
CC core-setting.c
CC core-thrash.c
CC core-time.c
CC core-helper.c
CC stress-ng.c
CC core-parse-opts.c
CC core-madvise.c
CC core-mincore.c
CC core-limit.c
CC core-out-of-memory.c
CC core-mounts.c
CC core-shim.c
CC stress-personality.c
CC core-perf.c
[91mstress-rawsock.c: In function 'stress_rawsock':
stress-rawsock.c:143:43: warning: passing argument 5 of 'recvfrom' from incompatible pointer type [-Wincompatible-pointer-types]
    n = recvfrom(fd, &pkt, sizeof(pkt), 0, &addr, &len);
                                           ^~~~~
In file included from /usr/include/netinet/in.h:10,
                 from /usr/include/arpa/inet.h:9,
                 from stress-ng.h:76,
                 from stress-rawsock.c:25:
/usr/include/fortify/sys/socket.h:46:57: note: expected 'struct sockaddr *' but argument is of type 'struct sockaddr_in *'
                                        struct sockaddr *__a, socklen_t *__l)
                                        ~~~~~~~~~~~~~~~~~^~~
[0mLD stress-ng
make[1]: Leaving directory '/code/stress-ng'
Removing intermediate container f5c2cd0766bd
 ---> c738c1b55664
Step 10/20 : RUN cd / && git clone https://github.com/dagwieers/dstat.git
 ---> Running in 21d6cf1b68cc
[91mCloning into 'dstat'...
[0mRemoving intermediate container 21d6cf1b68cc
 ---> dc1e8a2cd271
Step 11/20 : COPY ./dstat-types.patch /dstat/dstat-types.patch
 ---> d5bcd569d253
Step 12/20 : RUN cd /dstat &&     patch <dstat-types.patch
 ---> Running in b06a42e34096
patching file dstat
Removing intermediate container b06a42e34096
 ---> cf7619074041
Step 13/20 : FROM alpine
 ---> 915beeae4675
Step 14/20 : MAINTAINER Kinvolk
 ---> Using cache
 ---> c497b8e9fbe5
Step 15/20 : RUN apk add --update --no-cache py2-six
 ---> Running in 30bdea67bad1
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/aarch64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/aarch64/APKINDEX.tar.gz
(1/12) Installing py-enum34 (1.1.6-r3)
(2/12) Installing libbz2 (1.0.6-r7)
(3/12) Installing expat (2.2.8-r0)
(4/12) Installing libffi (3.2.1-r6)
(5/12) Installing gdbm (1.13-r1)
(6/12) Installing ncurses-terminfo-base (6.1_p20190518-r0)
(7/12) Installing ncurses-terminfo (6.1_p20190518-r0)
(8/12) Installing ncurses-libs (6.1_p20190518-r0)
(9/12) Installing readline (8.0.0-r0)
(10/12) Installing sqlite-libs (3.28.0-r1)
(11/12) Installing python2 (2.7.16-r1)
(12/12) Installing py2-six (1.12.0-r1)
Executing busybox-1.30.1-r2.trigger
OK: 53 MiB in 26 packages
Removing intermediate container 30bdea67bad1
 ---> 88695ec4df77
Step 16/20 : COPY --from=builder /code/stress-ng/stress-ng /sbin/
 ---> 0e120c1632b2
Step 17/20 : COPY --from=builder /dstat/dstat /usr/local/bin/
 ---> a1efa641f6f5
Step 18/20 : COPY --from=builder /dstat/plugins /usr/local/bin/
 ---> 0b4ff561ffbc
Step 19/20 : USER nobody
 ---> Running in a215218130c9
Removing intermediate container a215218130c9
 ---> d320a5091188
Step 20/20 : WORKDIR /tmp
 ---> Running in d522efaf9cc6
Removing intermediate container d522efaf9cc6
 ---> d22528817f17
Successfully built d22528817f17
Successfully tagged stress-ng:latest
</pre>

*run*
Please note that I only tested running this with docker directly as I currently do not have access to an ARM Lokomotive cluster. The yaml file therefore effectively remains untested.
<pre>
/tmp $ touch metrics.csv; stress-ng --cpu 4 --io 2 --vm 1 --vm-bytes 1G --timeout 60s --metrics-brief  & dstat --output metrics.csv >/dev/null 2>&1 & tail -f metrics.csv
stress-ng: info:  [34] dispatching hogs: 4 cpu, 2 io, 1 vm
stress-ng: info:  [34] cache allocate: using defaults, can't determine cache details from sysfs


"Host:","a4ac3051b47d",,,,"User:","nobody"
"Cmdline:","dstat --output metrics.csv",,,,"Date:","17 Oct 2019 10:05:45 "
"total cpu usage",,,,,"dsk/total",,"net/total",,"paging",,"system",
"usr","sys","idl","wai","stl","read","writ","recv","send","in","out","int","csw"
0.056,0.019,99.912,0.013,0,54410.468,23245.233,0,0,0,0,2272.756,2047.521
15.740,6.215,78.045,0,0,0,0,0,0,0,0,9330,1950
15.786,6.189,78.024,0,0,0,0,0,0,0,0,9604,2114
15.844,6.062,78.094,0,0,0,0,0,0,0,0,8682,2120
15.906,6.125,77.969,0,0,0,0,0,0,0,0,9275,2273
15.854,6.066,78.080,0,0,0,0,0,0,0,0,8817,2007
15.844,6.094,78.062,0,0,0,0,0,0,0,0,8693,2034
15.817,6.064,78.118,0,0,0,0,0,0,0,0,8790,2121
15.880,6.064,78.056,0,0,0,0,0,0,0,0,8504,2184
15.870,6.061,78.069,0,0,0,0,0,0,0,0,8803,1960
15.630,6.283,78.087,0,0,0,0,0,0,0,0,9088,1997
15.844,6.094,78.062,0,0,0,0,0,0,0,0,8798,2083
15.760,6.129,78.111,0,0,0,0,0,0,0,0,8553,1968
15.844,6.125,78.031,0,0,0,0,0,0,0,0,9054,2109
15.849,6.064,78.087,0,0,0,0,0,0,0,0,9132,2003
15.791,6.098,78.111,0,0,0,0,0,0,0,0,8502,1869
15.625,6.312,78.062,0,0,0,0,0,0,0,0,9087,2308
15.844,6.094,78.062,0,0,0,0,0,0,0,0,8710,1979
15.849,6.033,78.118,0,0,0,0,0,0,0,0,8519,1888
15.844,6.094,78.062,0,0,0,0,0,0,0,0,8664,1789
15.760,6.129,78.111,0,0,0,0,0,0,0,0,8687,1619
15.808,6.154,78.038,0,0,0,0,0,0,0,0,8787,1633
15.791,6.129,78.080,0,0,0,0,0,0,0,0,9389,2006
15.911,6.096,77.993,0,0,0,0,0,0,0,0,8987,1672
15.781,6.156,78.062,0,0,0,0,0,0,0,0,8838,1635
15.729,6.223,78.049,0,0,0,0,0,0,0,0,9004,1790
15.635,6.254,78.111,0,0,0,0,0,0,0,0,9026,1537
15.870,6.061,78.069,0,0,0,0,0,0,0,0,8853,1439
15.692,6.221,78.087,0,0,0,0,0,0,0,0,9061,1606
15.844,6.094,78.062,0,0,0,0,0,0,0,0,8927,1529
15.844,6.094,78.062,0,0,0,0,0,0,0,0,9032,1714
15.880,6.127,77.993,0,0,0,0,0,0,0,0,9516,2154
15.844,6.094,78.062,0,0,0,0,0,0,0,0,9115,1802
15.791,6.098,78.111,0,0,0,0,0,0,0,0,9073,1878
15.870,6.092,78.038,0,0,0,0,0,0,0,0,9016,1700
15.812,6.125,78.062,0,0,0,0,0,0,0,0,9045,1689
15.822,6.066,78.111,0,0,0,0,0,0,0,0,8915,1644
15.875,6.094,78.031,0,0,0,0,0,0,0,0,9119,1759
15.729,6.160,78.111,0,0,0,0,0,0,0,0,9191,1934
stress-ng: info:  [34] successful run completed in 60.09s (1 min, 0.09 secs)
stress-ng: info:  [34] stressor       bogo ops real time  usr time  sys time   bogo ops/s   bogo ops/s
stress-ng: info:  [34]                           (secs)    (secs)    (secs)   (real time) (usr+sys time)
stress-ng: info:  [34] cpu               18520     60.03    239.29      0.00       308.52        77.40
stress-ng: info:  [34] io              1437638     60.00      3.04    116.58     23960.60     12018.37
stress-ng: info:  [34] vm              1386356     60.00     59.28      0.45     23104.57     23210.38
</pre>
</details>