### PR TITLE
cluster-script: Kubernetes benchmark script

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,27 @@ platform / release specific. Also, the build contains a number of workarounds
 compensating for transient shortcomings in the Flatcar SDK.
 **Please note** that the build currently needs to be executed on a Flatcar
 instance.  We are working on improving the build.
+
+# Kubernetes cluster benchmark
+The `cluster-script` folder contains scripts to run the benchmark containers
+on Kubernetes clusters and compare the results.
+
+The `run-for-list.sh` script runs the benchmark for all clusters provided in
+a configuration file.
+
+The `benchmark.sh` script works on a single cluster per invocation.
+It covers automatic creation of K8s Jobs for sysbench cpu and memory benchmarks,
+gathering the results as CSV files and plotting them together with previous
+results as graphs for comparison.
+
+The benchmark results are stored in the cluster as long as the jobs
+are not cleaned-up. The gather process exports them to local files
+and combines the result with any existing local files.
+Therefore, the intended usage is to gather the results for various clusters
+into one directory.
+By keeping the cleanup process of Jobs in the cluster optional, multiple
+clients can access the results without sharing the CSV files.
+Old results can be cleaned-up to speed up the gathering and they are included
+in the plotted graphs as long as their CSV files are still in the current folder.
+
+

--- a/cluster-script/benchmark.sh
+++ b/cluster-script/benchmark.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -euo pipefail
+
+COMBINATIONS="benchmark+gather benchmark+gather+plot gather+plot gather+plot+cleanup benchmark+gather+cleanup benchmark+gather+plot+cleanup"
+
+if [ "$#" != 1 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+  echo "Usage: $0 benchmark|gather|plot|cleanup|COMBINATION"
+  echo "  benchmark: Runs benchmarks as Kubernetes Jobs on the cluster (starts sequentially with waiting for completion)"
+  echo "  gather:    Write the Kubernetes Job output to local CSV files"
+  echo "  plot:      Plot all existing CSVs in the current folder as SVGs"
+  echo "  cleanup:   Deletes the Kubernetes Jobs (optional cleanup)"
+  echo "  (Valid combinations: $COMBINATIONS)"
+  echo "Required env variables:"
+  echo "  KUBECONFIG: Specifies the cluster to use"
+  echo "  ARCH:       Specifies which container image suffix to use (either arm64 or amd64)"
+  echo "  COST:       Stores an additional cost/hour value, e.g., 1.0"
+  echo "  META:       Stores additional metadata about the benchmark run, use it to provide the location, e.g., sjc1 as the Packet datacenter region"
+  echo "Optional env variables:"
+  echo "  ITERATIONS=1: Number of runs inside a Job"
+  echo
+  echo "The benchmark results are stored in the cluster as long as the jobs are not cleaned-up."
+  echo "The gather process exports them to local files and combines the result with any existing local files."
+  echo "Therefore, the intended usage is to gather the results for various clusters into one directory."
+  echo "By keeping the cleanup process of Jobs in the cluster optional, multiple clients can access the results without sharing the CSV files."
+  echo "Old results can be cleaned-up to speed up the gathering and they are included in the plotted graphs as long as their CSV files are still in the current folder."
+  exit 0
+fi
+arg="$1"
+
+filtered="$(echo "$arg"; echo valid)"
+for a in benchmark gather plot cleanup $COMBINATIONS; do
+  filtered="$(echo "$filtered" | grep -v "^$a$")"
+done
+if [ "$filtered" != "valid" ]; then
+  echo "ERROR: Unknown argument"; exit 1
+fi
+
+ITERATIONS="${ITERATIONS-1}"
+
+if [ "$arg" != "plot" ]; then
+  # Test if required env variables are set
+  echo "$KUBECONFIG $ARCH $COST $META" > /dev/null
+  # Log them for the user for awareness
+  echo "KUBECONFIG=\"$KUBECONFIG\" ARCH=\"$ARCH\" COST=\"$COST\" META=\"$META\" ITERATIONS=\"$ITERATIONS\""
+fi
+
+# Assuming that the envsubst templates are in the same folder as this script
+P="$(dirname "$(readlink -f "$(which "$0")")")"
+# List of benchmarks: JOBTYPE,JOBNAME,PARAMETER,RESULT
+# Warning, the one JOBNAME should not be a valid prefix for another because of globbing.
+VARS='sysbench,fileio-one,--threads=1,MiB/sec sysbench,fileio-cores,--threads=$CORES,MiB/sec sysbench,fileio-all,--threads=$CPUS,MiB/sec'
+VARS+=' sysbench,mem-one,--threads=1,MiB/sec sysbench,mem-cores,--threads=$CORES,MiB/sec sysbench,mem-all,--threads=$CPUS,MiB/sec'
+VARS+=' sysbench,cpu-one,--threads=1,Events/s sysbench,cpu-cores,--threads=$CORES,Events/s sysbench,cpu-all,--threads=$CPUS,Events/s'
+
+if [ "$(echo "$arg" | grep benchmark)" != "" ]; then
+  for VAR in $VARS; do
+    IFS=, read -r JOBTYPE JOBNAME PARAMETER RESULT <<< "$VAR"
+    MODE="$JOBNAME"
+    ID="$(date +%s%4N | tail -c +5)-$RANDOM"
+    echo "starting $JOBTYPE$JOBNAME$ID"
+    export MODE ID PARAMETER RESULT ARCH COST META ITERATIONS
+    # Here "export" is needed so that the envubst process can see the variables
+    cat "$P/$JOBTYPE.envsubst" | envsubst '$MODE $ID $PARAMETER $RESULT $ARCH $COST $META $ITERATIONS' | kubectl apply -f -
+    while true; do
+      status="$(kubectl get job -n benchmark "$JOBTYPE$JOBNAME$ID" --output=jsonpath='{.status.conditions[0].type}')"
+      if [ "$status" = Complete ]; then
+        break
+      elif [ "$status" = Failed ]; then
+        echo "ERROR: Job failed:"
+        kubectl get job -n benchmark "$JOBTYPE$JOBNAME$ID"
+        exit 1
+      fi
+      sleep 1
+    done
+    echo "finished $JOBTYPE$JOBNAME"
+  done
+  echo "done with benchmarking"
+fi
+if [ "$(echo "$arg" | grep gather)" != "" ]; then
+  for VAR in $VARS; do
+    IFS=, read -r JOBTYPE JOBNAME PARAMETER RESULT <<< "$VAR"
+    jobs="$(kubectl get jobs -n benchmark --selector=app="$JOBTYPE$JOBNAME" --output=jsonpath='{.items[*].metadata.name}')"
+    for j in $jobs; do
+      kubectl logs -n benchmark "$(kubectl get pods -n benchmark --selector=job-name="$j" --output=jsonpath='{.items[*].metadata.name}')" |  grep '^CSV:' | cut -d : -f 2- > "$j$ARCH.csv"
+    done
+  done
+  echo "done gathering"
+fi
+if [ "$(echo "$arg" | grep plot)" != "" ]; then
+  for VAR in $VARS; do
+    IFS=, read -r JOBTYPE JOBNAME PARAMETER RESULT <<< "$VAR"
+    "$P/plot" --parameter --outfile="$JOBTYPE$JOBNAME.svg" "$RESULT" "$JOBTYPE$JOBNAME"*csv
+    "$P/plot" --parameter --outfile="$JOBTYPE$JOBNAME.png" "$RESULT" "$JOBTYPE$JOBNAME"*csv
+    "$P/plot" --cost --parameter --outfile="$JOBTYPE$JOBNAME-cost.svg" "$RESULT" "$JOBTYPE$JOBNAME"*csv
+    "$P/plot" --cost --parameter --outfile="$JOBTYPE$JOBNAME-cost.png" "$RESULT" "$JOBTYPE$JOBNAME"*csv
+  done
+  echo "done plotting"
+fi
+if [ "$(echo "$arg" | grep cleanup)" != "" ]; then
+  for VAR in $VARS; do
+    IFS=, read -r JOBTYPE JOBNAME RESULT <<< "$VAR"
+    jobs="$(kubectl get jobs -n benchmark --selector=app="$JOBTYPE$JOBNAME" --output=jsonpath='{.items[*].metadata.name}')"
+    for j in $jobs; do
+      kubectl delete job -n benchmark "$j"
+    done
+  done
+  echo "done with cleanup"
+fi

--- a/cluster-script/plot
+++ b/cluster-script/plot
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import numpy as np
+import pandas as pd
+import matplotlib
+import matplotlib.pyplot as plt
+import argparse
+
+parser = argparse.ArgumentParser(description="Plot two CSV results for comparison.")
+parser.add_argument("--parameter", dest="parameter", action="store_true", help="Include parameter in description")
+parser.add_argument("--outfile", type=str, help="Name of the SVG output file")
+parser.add_argument("--cost", dest="cost", action="store_true", help="Plot perf/cost")
+parser.add_argument("resultcolumn", type=str)
+parser.add_argument("csvfiles", type=str, nargs='+', help="CSV files")
+parser.set_defaults(logy=False, outfile='out.svg')
+args = parser.parse_args()
+
+d = pd.concat([pd.read_csv(i) for i in args.csvfiles])
+
+title = d['Name'].values[0] + ((': ' + d['Parameter'].values[0]) if args.parameter else '')
+types = 'System'
+results = args.resultcolumn
+d = d.sort_values(by=[types])
+d[types] = [l.replace(' (', '\n(') for l in d[types]]
+if args.cost:
+  costs = results + '/$'
+  d[costs] = [float(l)/float(c) for l, c in zip(d[results], d['Cost'])]
+  results = costs
+ts = d[types].unique()
+
+df = pd.DataFrame({types: ts, results: [d[d[types]==t][results].mean() for t in ts], 'std': [d[d[types]==t][results].std() for t in ts]})
+
+fontsize = 18
+plt.rc('legend', fontsize=fontsize)  # see https://stackoverflow.com/a/39566040 for more options
+plt.rc('font', size=fontsize)
+plt.rc('axes', labelsize=fontsize)
+p=df.plot(kind='barh', x=types, y=results, xerr='std', title=title, figsize=(15, 8), fontsize=fontsize)
+
+plt.tight_layout()
+plt.savefig(args.outfile)

--- a/cluster-script/run-for-list.sh
+++ b/cluster-script/run-for-list.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" != 2 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+  echo "Usage: $0 FILE ARG"
+  echo "Runs 'benchmark.sh ARG' for each cluster entry in FILE."
+  echo "FILE contains one cluster entry per line, stored as comma-separated values"
+  echo "(no whitespaces before or after comma) in the following order:"
+  echo "KUBECONFIG,ARCH,COST,META,ITERATIONS"
+  echo "The values are used as env vars for benchmark.sh."
+  echo "A final 'benchmark.sh plot' run is done if 'gather' is part of ARG."
+  exit 0
+fi
+FILE="$1"
+ARG="$2"
+
+# Assuming that benchmark.sh is in the same folder as this script
+P="$(dirname "$(readlink -f $(which "$0"))")"
+
+WAIT=""
+while IFS= read -r line || [ -n "$line" ]; do
+  IFS=, read KUBECONFIG ARCH COST META ITERATIONS <<< "$line"
+  export KUBECONFIG ARCH COST META ITERATIONS
+  "$P/benchmark.sh" "$ARG" &
+  WAIT+="$! "
+  if [ "$ARG" = plot ]; then
+    break  # running once is enough
+  fi
+done < "$FILE"
+
+wait $WAIT
+
+if [ "$(echo "$ARG" | grep gather)" != "" ] && [ "$ARG" != cleanup ]; then
+  "$P/benchmark.sh" plot
+fi

--- a/cluster-script/sysbench.envsubst
+++ b/cluster-script/sysbench.envsubst
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sysbench$MODE$ID
+  namespace: benchmark
+  labels:
+    app: sysbench$MODE
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 1000
+      volumes:
+      - name: tmpfs-volume
+        emptyDir:
+          medium: Memory
+      containers:
+      - name: cont
+        resources:
+          requests:
+            cpu: 1
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmpfs-volume
+        image: quay.io/kinvolk/sysbench:latest-$ARCH
+        command: ["/bin/sh", "-c"]
+        args:
+          - |-
+            set -eu
+            # Runs in busybox: the space in '$( (' is needed for a busybox syntax failure.
+            SOCKETS="$(grep '^physical id' /proc/cpuinfo | sort | uniq | wc -l)"
+            if [ "$SOCKETS" = 0 ]; then
+              SOCKETS=1
+            fi
+            CPUS="$(grep '^processor' /proc/cpuinfo | wc -l)"
+            CORES="$(grep '^core id' /proc/cpuinfo | sort | uniq | wc -l)"
+            if [ "$CORES" = 0 ]; then
+              CORES="$CPUS"
+            fi
+            # Arithmetics, here it must be '$(('
+            CORES="$((CORES*SOCKETS))"
+            # Includes a workaround for missing cpuinfo entries for Ampere on the current kernels.
+            CPU="$( (grep 'model name' /proc/cpuinfo ; (if [ "$(uname -m)" = aarch64 ] && [ "$CPUS" = 32 ]; then echo Ampere eMAG; else echo unknown ; fi)) | head -n 1 | cut -d : -f 2- | xargs)"
+            HYPERTHREADING="$( ([ -f /sys/devices/system/cpu/smt/control ] && cat /sys/devices/system/cpu/smt/control) || echo n/a)"
+            SYSTEM="$CPU (Sockets: $SOCKETS. CPUs: $CPUS. Cores: $CORES. HT: $HYPERTHREADING)"
+            # MODE, PARAMETER, RESULT, ID, ITERATIONS, COST, and META are not shell variables. PARAMETER can contain references to shell variables, so it's quoted in '' in the CSV line.
+            if [ $MODE = mem-one ] || [ $MODE = mem-all ] || [ $MODE = mem-cores ]; then
+              echo "CSV:Name,Parameter,System,$RESULT,Job,Cost,Meta"
+              for i in $(seq 1 $ITERATIONS); do
+                sysbench $PARAMETER --time=30 memory --memory-total-size=500G run | tee /dev/stderr | grep 'MiB/sec' | cut -d '(' -f 2 | cut -d ' ' -f 1 | printf 'CSV:sysbench memory,$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
+              done
+            elif [ $MODE = cpu-one ] || [ $MODE = cpu-all ] || [ $MODE = cpu-cores ]; then
+              echo "CSV:Name,Parameter,System,$RESULT,Job,Cost,Meta"
+              for i in $(seq 1 $ITERATIONS); do
+                sysbench $PARAMETER --time=30 cpu run | tee /dev/stderr | grep 'events per second' | cut -d : -f 2 | xargs | printf 'CSV:sysbench cpu,$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
+              done
+            elif [ $MODE = fileio-one ] || [ $MODE = fileio-all ] || [ $MODE = fileio-cores ]; then
+              echo "CSV:Name,Parameter,System,$RESULT,Job,Cost,Meta"
+              cd /tmp
+              sysbench fileio --file-test-mode=rndwr prepare
+              for i in $(seq 1 $ITERATIONS); do
+                sysbench $PARAMETER --time=30 fileio --file-test-mode=rndwr run | tee /dev/stderr | grep 'written, MiB/s' | cut -d : -f 2 | xargs | printf 'CSV:sysbench fileio --file-test-mode=rndwr,$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
+              done
+            else
+              echo "ERROR: Unknown mode"
+              exit 1
+            fi
+      restartPolicy: Never
+  backoffLimit: 0


### PR DESCRIPTION
The script works on a single cluster per invocation.
It covers automatic creation of K8s Jobs for sysbench
cpu and memory benchmarks, gathering the results as CSV
files and plotting them together with previous results as
graphs for comparison.

The benchmark results are stored in the cluster as long as the jobs
are not cleaned-up. The gather process exports them to local files
and combines the result with any existing local files.
Therefore, the intended usage is to gather the results for various clusters
into one directory.
By keeping the cleanup process of Jobs in the cluster optional, multiple
clients can access the results without sharing the CSV files.
Old results can be cleaned-up to speed up the gathering and they are included
in the plotted graphs as long as their CSV files are still in the current folder.

_Initial version, there are many things to improve and add…_

Here a preview:

![sysbenchcpu](https://user-images.githubusercontent.com/1189130/67572187-0246cd80-f736-11e9-9aff-3169eb828a23.png)

![sysbenchmem](https://user-images.githubusercontent.com/1189130/67572192-05da5480-f736-11e9-8cd9-cd7bcecabef2.png)


The memory benchmark is really a single thread only, so not shared memory access of all cores which would divide the bandwidth between the cores. I'll add this as well soon because it shows if the relation of memory bandwidth to core count leads to a bottleneck.
Also there are no graphs for perf/cost yet.