### PR TITLE
Add lscpu to all benchmark containers

### DIFF
--- a/fio/Dockerfile
+++ b/fio/Dockerfile
@@ -18,5 +18,5 @@ RUN apk add --update --no-cache py2-six
 COPY --from=dstat-builder /dstat/dstat /usr/local/bin
 COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
 # fio
-RUN apk add --update --no-cache libaio zlib so:libgcc_s.so.1
+RUN apk add --update --no-cache util-linux libaio zlib so:libgcc_s.so.1
 COPY --from=builder /fio/fio /usr/local/bin

--- a/iperf3/Dockerfile
+++ b/iperf3/Dockerfile
@@ -17,5 +17,5 @@ RUN apk add --update --no-cache py2-six
 COPY --from=dstat-builder /dstat/dstat /usr/local/bin
 COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
 # iperf3
-RUN apk add --update --no-cache openssl
+RUN apk add --update --no-cache util-linux openssl
 COPY --from=builder /iperf3/ /

--- a/stress-ng/Dockerfile
+++ b/stress-ng/Dockerfile
@@ -17,4 +17,5 @@ RUN apk add --update --no-cache py2-six
 COPY --from=dstat-builder /dstat/dstat /usr/local/bin
 COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
 # stress-ng
+RUN apk add --update --no-cache util-linux
 COPY --from=builder /stress-ng/stress-ng /sbin/

--- a/sysbench/Dockerfile
+++ b/sysbench/Dockerfile
@@ -19,5 +19,5 @@ RUN apk add --update --no-cache py2-six
 COPY --from=dstat-builder /dstat/dstat /usr/local/bin
 COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
 # sysbench
-RUN apk add --update --no-cache so:libgcc_s.so.1 so:libmariadb.so.3 so:libaio.so.1
+RUN apk add --update --no-cache util-linux so:libgcc_s.so.1 so:libmariadb.so.3 so:libaio.so.1
 COPY --from=builder /sysbench/sysbench-install-root/ /


### PR DESCRIPTION
This change adds the package util-linux to all benchmark
container images. Util-linux ships lscpu, which our benchmark
automation uses to determine architecture, cores, cpus, and threads
when parametrising benchmark runs.