### PR TITLE
Add stress-ng benchmark

### DIFF
--- a/cluster-script/k8s-job.envsubst
+++ b/cluster-script/k8s-job.envsubst
@@ -67,6 +67,10 @@ spec:
               for i in $(seq 1 $ITERATIONS); do
                 sysbench --threads=$PARAMETER --time=30 fileio --file-test-mode=rndwr run | tee /dev/stderr | grep 'written, MiB/s' | cut -d : -f 2 | xargs | printf 'CSV:sysbench fileio --file-test-mode=rndwr,--threads=$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
               done
+            elif [ $JOBTYPE = stress-ng ]; then
+              for i in $(seq 1 $ITERATIONS); do
+                stress-ng --$MODE $PARAMETER --timeout 30s --metrics-brief 2>&1 | grep $MODE | tail -n 1 | awk '{print $9}' | printf 'CSV:stress-ng $MODE,threads=$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
+              done
             else
               echo "ERROR: Unknown mode"
               exit 1

--- a/cluster-script/run-for-list.sh
+++ b/cluster-script/run-for-list.sh
@@ -9,6 +9,9 @@ if [ "$#" != 2 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   echo "KUBECONFIG,ARCH,COST,META,ITERATIONS"
   echo "The values are used as env vars for benchmark.sh."
   echo "A final 'benchmark.sh plot' run is done if 'gather' is part of ARG."
+  echo
+  echo "The env vars SYSBENCH and STRESSNG accept a space-separated list of"
+  echo "benchmarks (currently limited for SYSBENCH but generic for STRESSNG)."
   exit 0
 fi
 FILE="$1"


### PR DESCRIPTION
The list of stress-ng benchmarks is not final and consists of those I found interesting.

I also changed the job name encoding to include the parameter, so that the k8s app template can get simpler.
