### PR TITLE
memtier: Add util-linux for lscpu binary

### DIFF
--- a/memtier/Dockerfile
+++ b/memtier/Dockerfile
@@ -36,6 +36,8 @@ MAINTAINER Kinvolk
 RUN apk add --update --no-cache py2-six
 COPY --from=dstat-builder /dstat/dstat /usr/local/bin
 COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
+# lscpu
+RUN apk add --update --no-cache util-linux
 # memcached, redis, memtier
 RUN apk add --update --no-cache pcre libevent zlib so:libstdc++.so.6 so:libgcc_s.so.1
 COPY --from=builder /memcached/ /


### PR DESCRIPTION
The `lscpu` tool is missing on the memtier benchmark container, causing the CPU detection to fail.