### PR TITLE
cluster-script: Select node to schedule pods on right architecture

### DIFF
--- a/cluster-script/k8s-job.envsubst
+++ b/cluster-script/k8s-job.envsubst
@@ -23,6 +23,8 @@ spec:
         configMap:
           name: cpu-script
           defaultMode: 0777
+      nodeSelector:
+        kubernetes.io/arch: $ARCH
       containers:
       - name: cont
         resources:


### PR DESCRIPTION
In a hybrid cluster the pods should not be scheduled on nodes with the wrong architecture.