### PR TITLE
cluster-script: Add iperf3 and nginx benchmark with a special server node

### DIFF
--- a/ab/Dockerfile
+++ b/ab/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+MAINTAINER Kinvolk
+# dstat
+RUN apk add --update --no-cache py2-six
+COPY --from=dstat-builder /dstat/dstat /usr/local/bin
+COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
+# lscpu
+RUN apk add --update --no-cache util-linux
+# ab
+RUN apk add --update --no-cache apache2-utils

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Docker build helper to build one, or multiple, benchmark container(s)
 
-targets="fio stress-ng sysbench iperf3 memtier"
+targets="fio stress-ng sysbench iperf3 memtier nginx"
 cmdl_targets=""
 
 build_root=$(dirname "${BASH_SOURCE[0]}")

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Docker build helper to build one, or multiple, benchmark container(s)
 
-targets="fio stress-ng sysbench iperf3 memtier nginx"
+targets="fio stress-ng sysbench iperf3 memtier nginx ab"
 cmdl_targets=""
 
 build_root=$(dirname "${BASH_SOURCE[0]}")

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Docker build helper to build one, or multiple, benchmark container(s)
 
-targets="fio stress-ng sysbench iperf3 memtier nginx ab"
+targets="fio stress-ng sysbench iperf3 memtier nginx ab fortio"
 cmdl_targets=""
 
 build_root=$(dirname "${BASH_SOURCE[0]}")

--- a/cluster-script/benchmark.sh
+++ b/cluster-script/benchmark.sh
@@ -16,8 +16,10 @@ if [ "$#" != 1 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   echo "  ARCH:       Specifies which container image suffix to use (either arm64 or amd64)"
   echo "  COST:       Stores an additional cost/hour value, e.g., 1.0"
   echo "  META:       Stores additional metadata about the benchmark run, use it to provide the location, e.g., sjc1 as the Packet datacenter region"
+  echo "  NETWORKNODE: Specifies the node to label as server for the network benchmarks. It should have the same hardware."
   echo "Optional env variables:"
   echo "  ITERATIONS=1:                   Number of runs inside a Job"
+  echo "  NETWORK=\"iperf3\":               Space-separated list of network benchmarks to run (limited to the named ones)"
   echo "  MEMTIER=\"memcached redis\":      Space-separated list of memtier benchmarks to run (limited to the named ones)"
   echo "  SYSBENCH=\"fileio mem cpu\":      Space-separated list of sysbench benchmarks to run (limited to the named ones)"
   echo "  STRESSNG=\"(default in source)\": Space-separated list of stress-ng benchmarks to run (accepts any valid names)"
@@ -44,14 +46,15 @@ ITERATIONS="${ITERATIONS-1}"
 
 if [ "$arg" != "plot" ]; then
   # Test if required env variables are set
-  echo "$KUBECONFIG $ARCH $COST $META" > /dev/null
+  echo "$KUBECONFIG $ARCH $COST $META $NETWORKNODE" > /dev/null
   # Log them for the user for awareness
-  echo "KUBECONFIG=\"$KUBECONFIG\" ARCH=\"$ARCH\" COST=\"$COST\" META=\"$META\" ITERATIONS=\"$ITERATIONS\""
+  echo "KUBECONFIG=\"$KUBECONFIG\" ARCH=\"$ARCH\" COST=\"$COST\" META=\"$META\" ITERATIONS=\"$ITERATIONS\" NETWORKNODE=\"$NETWORKNODE\""
 fi
 
 STRESSNG="${STRESSNG-spawn hsearch crypt atomic tsearch qsort shm sem lsearch bsearch vecmath matrix memcpy}"
 SYSBENCH="${SYSBENCH-fileio mem cpu}"
 MEMTIER="${MEMTIER-memcached redis}"
+NETWORK="${NETWORK-iperf3}"
 
 # List of benchmarks: JOBTYPE,JOBNAME,PARAMETER,RESULT
 # Warning, $JOBTYPE$JOBNAME$PARAMETER should not be a valid prefix for another because of globbing.
@@ -70,12 +73,22 @@ for S in $SYSBENCH; do
   fi
   VARS+="$(printf ' sysbench,%s,$ONE,%s sysbench,%s,$CORES,%s sysbench,%s,$CPUS,%s' "$S" "$COL" "$S" "$COL" "$S" "$COL")"
 done
+for S in $NETWORK; do
+  if [ "$S" = iperf3 ]; then
+    VARS+=' iperf3,tcp,$ONE,MBit/s iperf3,tcp,$CORES,MBit/s iperf3,tcp,$CPUS,MBit/s'
+  fi
+done
 
 if [ "$(echo "$arg" | grep benchmark)" != "" ]; then
   echo "Deploying helpers"
   kubectl apply -f "${script_dir}"/helpers.yaml
   for VAR in $VARS; do
     IFS=, read -r JOBTYPE JOBNAME PARAMETER RESULT <<< "$VAR"
+    if [ "$JOBTYPE" = iperf3 ]; then
+      kubectl label --overwrite=true nodes "$NETWORKNODE" benchmark-node=network-server
+      kubectl taint --overwrite=true nodes "$NETWORKNODE" benchmark-node=network-server:NoSchedule
+      cat "${script_dir}"/network-server.envsubst | envsubst '$ARCH' | kubectl apply -f -
+    fi
     MODE="$JOBNAME"
     ID="$(date +%s%4N | tail -c +5)-$RANDOM"
     PARAMETERQUOTE="$(echo "$PARAMETER" | sed -e 's/\$//' | sed -e 's/\///' | tr '[:upper:]' '[:lower:]')"
@@ -94,6 +107,10 @@ if [ "$(echo "$arg" | grep benchmark)" != "" ]; then
       fi
       sleep 1
     done
+    if [ "$JOBTYPE" = iperf3 ]; then
+      cat "${script_dir}"/network-server.envsubst | envsubst '$ARCH' | kubectl delete -f -
+      kubectl taint nodes "$NETWORKNODE" benchmark-node:NoSchedule-
+    fi
     echo "finished $JOBTYPE-$JOBNAME-$PARAMETERQUOTE"
   done
   echo "done with benchmarking"

--- a/cluster-script/k8s-job.envsubst
+++ b/cluster-script/k8s-job.envsubst
@@ -114,6 +114,15 @@ spec:
                 printf 'CSV:memtier $MODE,%s=$PARAMETER,%s,%s,$ID,$COST,$META\n' "$TYPE" "$SYSTEM" "$SUM"
               done
               killall redis-server memcached || true
+            elif [ $JOBTYPE = iperf3 ] && [ $MODE = tcp ]; then
+              PORT=6000
+              while ! echo | nc iperf3-service "$PORT"; do
+                echo "Waiting for iperf3-service..."
+                sleep 1
+              done
+              for i in $(seq 1 $ITERATIONS); do
+                iperf3 -p "$PORT" -P $PARAMETER -c iperf3-service --time 30 -J | tee /dev/stderr | grep bits_per_second | tail -n 1 | cut -d : -f 2 | cut -d , -f 1 | cut -d . -f 1 | xargs | echo "$(( $(cat)/1000/1000 ))" | printf '\nCSV:iperf3 $MODE,streams=$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
+              done
             else
               echo "ERROR: Unknown mode"
               exit 1

--- a/cluster-script/k8s-job.envsubst
+++ b/cluster-script/k8s-job.envsubst
@@ -114,7 +114,7 @@ spec:
                 printf 'CSV:memtier $MODE,%s=$PARAMETER,%s,%s,$ID,$COST,$META\n' "$TYPE" "$SYSTEM" "$SUM"
               done
               killall redis-server memcached || true
-            elif [ $JOBTYPE = iperf3 ] && [ $MODE = tcp ]; then
+            elif [ $JOBTYPE = iperf3 ] && [ $MODE = iperf3 ]; then
               PORT=6000
               while ! echo | nc iperf3-service "$PORT"; do
                 echo "Waiting for iperf3-service..."
@@ -122,6 +122,15 @@ spec:
               done
               for i in $(seq 1 $ITERATIONS); do
                 iperf3 -p "$PORT" -P $PARAMETER -c iperf3-service --time 30 -J | tee /dev/stderr | grep bits_per_second | tail -n 1 | cut -d : -f 2 | cut -d , -f 1 | cut -d . -f 1 | xargs | echo "$(( $(cat)/1000/1000 ))" | printf '\nCSV:iperf3 $MODE,streams=$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
+              done
+            elif [ $JOBTYPE = ab ] && [ $MODE = nginx ]; then
+              PORT=8000
+              while ! echo | nc nginx-service "$PORT"; do
+                echo "Waiting for nginx-service..."
+                sleep 1
+              done
+              for i in $(seq 1 $ITERATIONS); do
+                ab -c $PARAMETER -t 30 -n 999999999 http://nginx-service:8000/ 2>&1 | tee /dev/stderr | grep 'Requests per second' | awk '{print $4}' | printf '\nCSV:ab $MODE,connections=$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
               done
             else
               echo "ERROR: Unknown mode"

--- a/cluster-script/network-server.envsubst
+++ b/cluster-script/network-server.envsubst
@@ -1,27 +1,27 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: iperf3-service
+  name: $JOBNAME-service
   namespace: benchmark
 spec:
   clusterIP: None
   selector:
-    app: iperf3
+    app: $JOBNAME
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: iperf3
+  name: $JOBNAME
   namespace: benchmark
 spec:
   selector:
     matchLabels:
-      app: iperf3
+      app: $JOBNAME
   replicas: 1
   template:
     metadata:
       labels:
-        app: iperf3
+        app: $JOBNAME
     spec:
       securityContext:
         runAsUser: 1000
@@ -53,9 +53,9 @@ spec:
             mountPath: /scripts/cpu.sh
             subPath: cpu.sh
         imagePullPolicy: Always
-        image: quay.io/kinvolk/iperf3:latest-$ARCH
+        image: quay.io/kinvolk/$JOBNAME:latest-$ARCH
         ports:
-          - containerPort: 6000
+          - containerPort: $PORT
         command: ["/bin/sh", "-c"]
         args:
           - |-
@@ -67,4 +67,11 @@ spec:
             HYPERTHREADING=$(/scripts/cpu.sh ht)
             SYSTEM="$CPU (Sockets: $SOCKETS. CPUs: $CPUS. Cores: $CORES. HT: $HYPERTHREADING)"
             echo "$SYSTEM"
-            iperf3 -s -p 6000
+            if [ $JOBNAME = iperf3 ]; then
+              iperf3 -s -p $PORT
+            elif [ $JOBNAME = nginx ]; then
+              nginx -g "daemon off;"
+            else
+              echo "Unknown JOBNAME"
+              exit 1
+            fi

--- a/cluster-script/network-server.envsubst
+++ b/cluster-script/network-server.envsubst
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: iperf3-service
+  namespace: benchmark
+spec:
+  clusterIP: None
+  selector:
+    app: iperf3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iperf3
+  namespace: benchmark
+spec:
+  selector:
+    matchLabels:
+      app: iperf3
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: iperf3
+    spec:
+      securityContext:
+        runAsUser: 1000
+      volumes:
+      - name: tmpfs-volume
+        emptyDir:
+          medium: Memory
+      - name: cpu-script
+        configMap:
+          name: cpu-script
+          defaultMode: 0777
+      nodeSelector:
+        kubernetes.io/arch: $ARCH
+        benchmark-node: network-server
+      tolerations:
+      - key: benchmark-node
+        operator: "Equal"
+        value: "network-server"
+        effect: "NoSchedule"
+      containers:
+      - name: cont
+        resources:
+          requests:
+            cpu: 1
+        volumeMounts:
+          - mountPath: /tmp
+            name: tmpfs-volume
+          - name: cpu-script
+            mountPath: /scripts/cpu.sh
+            subPath: cpu.sh
+        imagePullPolicy: Always
+        image: quay.io/kinvolk/iperf3:latest-$ARCH
+        ports:
+          - containerPort: 6000
+        command: ["/bin/sh", "-c"]
+        args:
+          - |-
+            set -eu
+            SOCKETS=$(/scripts/cpu.sh sockets)
+            CPUS=$(/scripts/cpu.sh cpus)
+            CORES=$(/scripts/cpu.sh cores)
+            CPU=$(/scripts/cpu.sh model)
+            HYPERTHREADING=$(/scripts/cpu.sh ht)
+            SYSTEM="$CPU (Sockets: $SOCKETS. CPUs: $CPUS. Cores: $CORES. HT: $HYPERTHREADING)"
+            echo "$SYSTEM"
+            iperf3 -s -p 6000

--- a/cluster-script/run-for-list.sh
+++ b/cluster-script/run-for-list.sh
@@ -6,7 +6,7 @@ if [ "$#" != 2 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   echo "Runs 'benchmark.sh ARG' for each cluster entry in FILE."
   echo "FILE contains one cluster entry per line, stored as comma-separated values"
   echo "(no whitespaces before or after comma) in the following order:"
-  echo "KUBECONFIG,ARCH,COST,META,ITERATIONS"
+  echo "KUBECONFIG,ARCH,COST,META,ITERATIONS,NETWORKNODE"
   echo "The values are used as env vars for benchmark.sh."
   echo "A final 'benchmark.sh plot' run is done if 'gather' is part of ARG."
   echo
@@ -22,8 +22,8 @@ P="$(dirname "$(readlink -f $(which "$0"))")"
 
 WAIT=""
 while IFS= read -r line || [ -n "$line" ]; do
-  IFS=, read KUBECONFIG ARCH COST META ITERATIONS <<< "$line"
-  export KUBECONFIG ARCH COST META ITERATIONS
+  IFS=, read KUBECONFIG ARCH COST META ITERATIONS NETWORKNODE <<< "$line"
+  export KUBECONFIG ARCH COST META ITERATIONS NETWORKNODE
   "$P/benchmark.sh" "$ARG" &
   WAIT+="$! "
   if [ "$ARG" = plot ]; then

--- a/fortio/Dockerfile
+++ b/fortio/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:alpine as builder
+RUN apk add --update git
+RUN go get fortio.org/fortio
+
+FROM alpine
+MAINTAINER Kinvolk
+# dstat
+RUN apk add --update --no-cache py2-six
+COPY --from=dstat-builder /dstat/dstat /usr/local/bin
+COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
+# lscpu
+RUN apk add --update --no-cache util-linux
+# fortio
+COPY --from=builder /go/bin/fortio /usr/local/bin/fortio
+COPY --from=builder /go/src/fortio.org /go/src/fortio.org

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine
+MAINTAINER Kinvolk
+# dstat
+RUN apk add --update --no-cache py2-six
+COPY --from=dstat-builder /dstat/dstat /usr/local/bin
+COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
+# lscpu
+RUN apk add --update --no-cache util-linux
+# nginx serving 404 on port 8000 running as benchmark user (switches if started as root)
+RUN apk add --update --no-cache nginx
+RUN adduser -u 1000 -D benchmark
+RUN sed -i 's/user nginx;/user benchmark;/g' /etc/nginx/nginx.conf
+RUN sed -i 's/80 default_server/8000 default_server/g' /etc/nginx/conf.d/default.conf
+RUN mkdir /run/nginx
+RUN chown benchmark:benchmark -R /var/lib/nginx /run/nginx/ /var/tmp/nginx /var/log/nginx
+CMD nginx -g "daemon off;"


### PR DESCRIPTION
For iperf3 single and multiple concurrent TCP streams are tested.
For nginx the max req/s are tested with `ab`. The amount on nginx workers comes from the CPU count. The benchmark runs `ab` once with one connection per CPU and then with one per core.

How to test:

1. Add a new worker by increasing the worker node count in terraform for each cluster
2. Add the worker node's name as last column to the input list for the `run-for-list.sh` command, e.g., add `,worker-1` at the end of each line if the new worker's name is `worker-1` and is the same on all clusters