### PR TITLE
cluster-script: Add fortio benchmark for HTTP/gRPC latency

### DIFF
--- a/cluster-script/benchmark.sh
+++ b/cluster-script/benchmark.sh
@@ -142,7 +142,7 @@ if [ "$(echo "$arg" | grep gather)" != "" ]; then
     PARAMETERQUOTE="$(echo "$PARAMETER" | sed -e 's/\$//' | sed -e 's/\///' | sed -e 's/ //g' | sed -e 's/=//g' | tr '[:upper:]' '[:lower:]')"
     jobs="$(kubectl get jobs -n benchmark --selector=app="$JOBTYPE-$JOBNAME-$PARAMETERQUOTE" --output=jsonpath='{.items[*].metadata.name}')"
     for j in $jobs; do
-      kubectl logs -n benchmark "$(kubectl get pods -n benchmark --selector=job-name="$j" --output=jsonpath='{.items[*].metadata.name}')" |  grep '^CSV:' | cut -d : -f 2- > "$j$ARCH.csv"
+      kubectl logs -n benchmark "$(kubectl get pods -n benchmark --selector=job-name="$j" --output=jsonpath='{.items[*].metadata.name}')" |  grep --binary-files=text '^CSV:' | cut -d : -f 2- > "$j$ARCH.csv"
     done
   count=$(( $count + 1 ))
   done

--- a/cluster-script/benchmark.sh
+++ b/cluster-script/benchmark.sh
@@ -79,7 +79,7 @@ for S in $NETWORK; do
   elif [ "$S" = ab ]; then
     VARS+=('ab,nginx,$CORES,HTTP-Req/s' 'ab,nginx,$CPUS,HTTP-Req/s')
   elif [ "$S" = fortio ]; then
-    VARS+=('fortio,fortio,-c $CPUS -qps=2000,p999 latency sec' 'fortio,fortio,-grpc -s 10 -c $CPUS -qps=2000,p999 latency sec')
+    VARS+=('fortio,fortio,-c 20 -qps=2000 -t=60s,p999 latency ms' 'fortio,fortio,-grpc -s 10 -c 20 -qps=2000 -t=60s,p999 latency ms')
   fi
 done
 VARS+=("")

--- a/cluster-script/k8s-job.envsubst
+++ b/cluster-script/k8s-job.envsubst
@@ -25,7 +25,7 @@ spec:
           defaultMode: 0777
       nodeSelector:
         kubernetes.io/arch: $ARCH
-        benchmark-node: benchmark-server
+        benchmark-node: $BENCHNODESELECTOR
       containers:
       - name: cont
         resources:
@@ -144,6 +144,10 @@ spec:
                 echo "Waiting for fortio-service..."
                 sleep 1
               done
+              while ! echo | nc fortio-service 9999 > /tmp/system-out; do
+                sleep 1
+              done
+              SYSTEM="$(cat /tmp/system-out)"
               for i in $(seq 1 $ITERATIONS); do
                 REQ_BODY_LEN=50
                 rm out.json || true

--- a/cluster-script/k8s-job.envsubst
+++ b/cluster-script/k8s-job.envsubst
@@ -132,6 +132,24 @@ spec:
               for i in $(seq 1 $ITERATIONS); do
                 ab -c $PARAMETER -t 30 -n 999999999 http://nginx-service:8000/ 2>&1 | tee /dev/stderr | grep 'Requests per second' | awk '{print $4}' | printf '\nCSV:ab $MODE,connections=$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
               done
+            elif [ $JOBTYPE = fortio ] && [ $MODE = fortio ]; then
+              cd /tmp
+              if echo "$PARAMETER" | grep grpc > /dev/null; then
+                PORT=8079
+              else
+                PORT=8080
+              fi
+              while ! echo | nc fortio-service "$PORT"; do
+                echo "Waiting for fortio-service..."
+                sleep 1
+              done
+              for i in $(seq 1 $ITERATIONS); do
+                REQ_BODY_LEN=50
+                rm out.json || true
+                fortio load $PARAMETER -t=30s -payload-size=50 -keepalive=false -labels='-payload-size=50 -keepalive=false $PARAMETER Iteration: '"$i" -json=out.json "fortio-service:$PORT"
+                cat out.json > /dev/stderr
+                tac out.json | grep -m 1 Value | cut  -d ':' -f 2 | xargs | printf '\nCSV:fortio,$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
+              done
             else
               echo "ERROR: Unknown mode"
               exit 1

--- a/cluster-script/k8s-job.envsubst
+++ b/cluster-script/k8s-job.envsubst
@@ -25,6 +25,7 @@ spec:
           defaultMode: 0777
       nodeSelector:
         kubernetes.io/arch: $ARCH
+        benchmark-node: benchmark-server
       containers:
       - name: cont
         resources:

--- a/cluster-script/k8s-job.envsubst
+++ b/cluster-script/k8s-job.envsubst
@@ -146,9 +146,9 @@ spec:
               for i in $(seq 1 $ITERATIONS); do
                 REQ_BODY_LEN=50
                 rm out.json || true
-                fortio load $PARAMETER -t=30s -payload-size=50 -keepalive=false -labels='-payload-size=50 -keepalive=false $PARAMETER Iteration: '"$i" -json=out.json "fortio-service:$PORT"
+                fortio load $PARAMETER -payload-size=50 -keepalive=false -labels='-payload-size=50 -keepalive=false $PARAMETER Iteration: '"$i" -json=out.json "fortio-service:$PORT"
                 cat out.json > /dev/stderr
-                tac out.json | grep -m 1 Value | cut  -d ':' -f 2 | xargs | printf '\nCSV:fortio,$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
+                tac out.json | grep -m 1 Value | cut  -d ':' -f 2 | xargs | printf '\nCSV:fortio,$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(awk "BEGIN{print "$(cat)"*1000}")"
               done
             else
               echo "ERROR: Unknown mode"

--- a/cluster-script/network-server.envsubst
+++ b/cluster-script/network-server.envsubst
@@ -36,11 +36,6 @@ spec:
       nodeSelector:
         kubernetes.io/arch: $ARCH
         benchmark-node: network-server
-      tolerations:
-      - key: benchmark-node
-        operator: "Equal"
-        value: "network-server"
-        effect: "NoSchedule"
       containers:
       - name: cont
         resources:

--- a/cluster-script/network-server.envsubst
+++ b/cluster-script/network-server.envsubst
@@ -35,7 +35,7 @@ spec:
           defaultMode: 0777
       nodeSelector:
         kubernetes.io/arch: $ARCH
-        benchmark-node: network-server
+        benchmark-node: $NETNODESELECTOR
       containers:
       - name: cont
         resources:
@@ -51,6 +51,7 @@ spec:
         image: quay.io/kinvolk/$JOBNAME:latest-$ARCH
         ports:
           - containerPort: $PORT
+          - containerPort: 9999
         command: ["/bin/sh", "-c"]
         args:
           - |-
@@ -62,6 +63,9 @@ spec:
             HYPERTHREADING=$(/scripts/cpu.sh ht)
             SYSTEM="$CPU (Sockets: $SOCKETS. CPUs: $CPUS. Cores: $CORES. HT: $HYPERTHREADING)"
             echo "$SYSTEM"
+            printf '#!/bin/sh\necho "%s"' "$SYSTEM" > /tmp/system
+            chmod +x /tmp/system
+            nc -lk -p 9999 -e /tmp/system &
             if [ $JOBNAME = iperf3 ]; then
               iperf3 -s -p $PORT
             elif [ $JOBNAME = nginx ]; then

--- a/cluster-script/network-server.envsubst
+++ b/cluster-script/network-server.envsubst
@@ -71,6 +71,8 @@ spec:
               iperf3 -s -p $PORT
             elif [ $JOBNAME = nginx ]; then
               nginx -g "daemon off;"
+            elif [ $JOBNAME = fortio ]; then
+              fortio server -ui-path ''
             else
               echo "Unknown JOBNAME"
               exit 1

--- a/cluster-script/run-for-list.sh
+++ b/cluster-script/run-for-list.sh
@@ -22,8 +22,8 @@ P="$(dirname "$(readlink -f $(which "$0"))")"
 
 WAIT=""
 while IFS= read -r line || [ -n "$line" ]; do
-  IFS=, read KUBECONFIG ARCH COST META ITERATIONS NETWORKNODE <<< "$line"
-  export KUBECONFIG ARCH COST META ITERATIONS NETWORKNODE
+  IFS=, read KUBECONFIG ARCH COST META ITERATIONS BENCHMARKNODE NETWORKNODE <<< "$line"
+  export KUBECONFIG ARCH COST META ITERATIONS BENCHMARKNODE NETWORKNODE
   "$P/benchmark.sh" "$ARG" &
   WAIT+="$! "
   if [ "$ARG" = plot ]; then

--- a/cluster-script/run-for-list.sh
+++ b/cluster-script/run-for-list.sh
@@ -6,7 +6,7 @@ if [ "$#" != 2 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   echo "Runs 'benchmark.sh ARG' for each cluster entry in FILE."
   echo "FILE contains one cluster entry per line, stored as comma-separated values"
   echo "(no whitespaces before or after comma) in the following order:"
-  echo "KUBECONFIG,ARCH,COST,META,ITERATIONS,NETWORKNODE"
+  echo "KUBECONFIG,ARCH,COST,META,ITERATIONS,BENCHMARKNODE,NETWORKNODE,FIXEDX86NODE"
   echo "The values are used as env vars for benchmark.sh."
   echo "A final 'benchmark.sh plot' run is done if 'gather' is part of ARG."
   echo
@@ -22,8 +22,8 @@ P="$(dirname "$(readlink -f $(which "$0"))")"
 
 WAIT=""
 while IFS= read -r line || [ -n "$line" ]; do
-  IFS=, read KUBECONFIG ARCH COST META ITERATIONS BENCHMARKNODE NETWORKNODE <<< "$line"
-  export KUBECONFIG ARCH COST META ITERATIONS BENCHMARKNODE NETWORKNODE
+  IFS=, read KUBECONFIG ARCH COST META ITERATIONS BENCHMARKNODE NETWORKNODE FIXEDX86NODE <<< "$line"
+  export KUBECONFIG ARCH COST META ITERATIONS BENCHMARKNODE NETWORKNODE FIXEDX86NODE
   "$P/benchmark.sh" "$ARG" &
   WAIT+="$! "
   if [ "$ARG" = plot ]; then


### PR DESCRIPTION
The request per second rate is 2000. Requests are made over 20 concurrent connections for 1 minute. The test uses a 50 byte payload and no keepalive connections. As result the highest percentile (99.9) latency is collected.

Needs to use a hybrid cluster to have fixed server type that measures latencies. This needs to be done with an additional worker pool (except if the fixed server has the same type as the current workers).

How to test:
Two new columns need to be added to the input list: network node and fixed x86 node:
`KUBECONFIG ARCH COST META ITERATIONS BENCHMARKNODE NETWORKNODE FIXEDX86NODE`