### PR TITLE
cluster-script: wrk2 latency benchmark for nginx

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Docker build helper to build one, or multiple, benchmark container(s)
 
-targets="fio stress-ng sysbench iperf3 memtier nginx ab fortio"
+targets="fio stress-ng sysbench iperf3 memtier nginx ab fortio wrk2-benchmark"
 cmdl_targets=""
 
 build_root=$(dirname "${BASH_SOURCE[0]}")

--- a/cluster-script/benchmark.sh
+++ b/cluster-script/benchmark.sh
@@ -20,12 +20,12 @@ if [ "$#" != 1 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   echo "  FIXEDX86NODE:  Specifies the node used as client to for network benchmarks. It should be the same x86 hardware for all clusters."
   echo "Optional env variables:"
   echo "  ITERATIONS=1:                   Number of runs inside a Job"
-  echo "  NETWORK=\"iperf3 ab fortio\":     Space-separated list of network benchmarks to run (limited to the named ones)"
-  echo "  MEMTIER=\"memcached redis\":      Space-separated list of memtier benchmarks to run (limited to the named ones)"
-  echo "  SYSBENCH=\"fileio mem cpu\":      Space-separated list of sysbench benchmarks to run (limited to the named ones)"
-  echo "  STRESSNG=\"(default in source)\": Space-separated list of stress-ng benchmarks to run (accepts any valid names)"
-  echo "                                  To disable sysbench or stress-ng benchmarks set them to a whitespace string but not"
-  echo "                                  an empty string. E.g., STRESSNG=\" \" SYSBENCH=\" \" disables both."
+  echo "  NETWORK=\"iperf3 ab fortio wrk2\": Space-separated list of network benchmarks to run (limited to the named ones)"
+  echo "  MEMTIER=\"memcached redis\":       Space-separated list of memtier benchmarks to run (limited to the named ones)"
+  echo "  SYSBENCH=\"fileio mem cpu\":       Space-separated list of sysbench benchmarks to run (limited to the named ones)"
+  echo "  STRESSNG=\"(default in source)\":  Space-separated list of stress-ng benchmarks to run (accepts any valid names)"
+  echo "                                   To disable sysbench or stress-ng benchmarks set them to a whitespace string but not"
+  echo "                                   an empty string. E.g., STRESSNG=\" \" SYSBENCH=\" \" disables both."
   echo "The benchmark results are stored in the cluster as long as the jobs are not cleaned-up."
   echo "The gather process exports them to local files and combines the result with any existing local files."
   echo "Therefore, the intended usage is to gather the results for various clusters into one directory."
@@ -82,6 +82,8 @@ for S in $NETWORK; do
     VARS+=('ab,nginx,56,HTTP-Req/s')
   elif [ "$S" = fortio ]; then
     VARS+=('fortio,fortio,-c 20 -qps=2000 -t=60s,p999 latency ms' 'fortio,fortio,-grpc -s 10 -c 20 -qps=2000 -t=60s,p999 latency ms')
+  elif [ "$S" = wrk2 ]; then
+    VARS+=('wrk2-benchmark,nginx,-d 60s -c 56 -t 56 -R 2000,p999 latency ms')
   fi
 done
 VARS+=("")
@@ -93,7 +95,7 @@ if [ "$(echo "$arg" | grep benchmark)" != "" ]; then
     IFS=, read -r JOBTYPE JOBNAME PARAMETER RESULT <<< "${VARS[count]}"
     BENCHNODESELECTOR="$BENCHMARKNODE"
     BENCHARCH="$ARCH"
-    if [ "$JOBTYPE" = iperf3 ] || [ "$JOBTYPE" = ab ] || [ "$JOBTYPE" = fortio ]; then
+    if [ "$JOBTYPE" = iperf3 ] || [ "$JOBTYPE" = ab ] || [ "$JOBTYPE" = fortio ] || [ "$JOBTYPE" = wrk2-benchmark ]; then
       # Run the benchmark client on the FIXEDX86NODE and the server on the BENCHMARKNODE
       BENCHNODESELECTOR="$FIXEDX86NODE"
       BENCHARCH=amd64
@@ -137,7 +139,7 @@ if [ "$(echo "$arg" | grep benchmark)" != "" ]; then
       fi
       sleep 1
     done
-    if [ "$JOBTYPE" = iperf3 ] || [ "$JOBTYPE" = ab ] || [ "$JOBTYPE" = fortio ]; then
+    if [ "$JOBTYPE" = iperf3 ] || [ "$JOBTYPE" = ab ] || [ "$JOBTYPE" = fortio ] || [ "$JOBTYPE" = wrk2-benchmark ]; then
       cat "${script_dir}"/network-server.envsubst | envsubst '$ARCH $JOBNAME $PORT $NETNODESELECTOR' | kubectl delete -f -
     fi
     echo "finished $JOBTYPE-$JOBNAME-$PARAMETERQUOTE"

--- a/cluster-script/benchmark.sh
+++ b/cluster-script/benchmark.sh
@@ -117,7 +117,7 @@ if [ "$(echo "$arg" | grep benchmark)" != "" ]; then
     fi
     MODE="$JOBNAME"
     ID="$(date +%s%4N | tail -c +5)-$RANDOM"
-    PARAMETERQUOTE="$(echo "$PARAMETER" | sed -e 's/\$//' | sed -e 's/\///' | sed -e 's/ //g' | sed -e 's/=//g' | tr '[:upper:]' '[:lower:]')"
+    PARAMETERQUOTE="$(echo "$PARAMETER" | sed -e 's/\$//g' | sed -e 's/\///g' | sed -e 's/ //g' | sed -e 's/=//g' | tr '[:upper:]' '[:lower:]')"
     echo "starting $JOBTYPE-$JOBNAME-$PARAMETERQUOTE-$ID"
     PREVARCH="$ARCH"
     ARCH="$BENCHARCH"
@@ -148,7 +148,7 @@ fi
 if [ "$(echo "$arg" | grep gather)" != "" ]; then
   count=0; while [ "x${VARS[count]}" != "x" ]; do
     IFS=, read -r JOBTYPE JOBNAME PARAMETER RESULT <<< "${VARS[count]}"
-    PARAMETERQUOTE="$(echo "$PARAMETER" | sed -e 's/\$//' | sed -e 's/\///' | sed -e 's/ //g' | sed -e 's/=//g' | tr '[:upper:]' '[:lower:]')"
+    PARAMETERQUOTE="$(echo "$PARAMETER" | sed -e 's/\$//g' | sed -e 's/\///g' | sed -e 's/ //g' | sed -e 's/=//g' | tr '[:upper:]' '[:lower:]')"
     jobs="$(kubectl get jobs -n benchmark --selector=app="$JOBTYPE-$JOBNAME-$PARAMETERQUOTE" --output=jsonpath='{.items[*].metadata.name}')"
     for j in $jobs; do
       kubectl logs -n benchmark "$(kubectl get pods -n benchmark --selector=job-name="$j" --output=jsonpath='{.items[*].metadata.name}')" |  grep --binary-files=text '^CSV:' | cut -d : -f 2- > "$j$ARCH.csv"
@@ -160,7 +160,7 @@ fi
 if [ "$(echo "$arg" | grep plot)" != "" ]; then
   count=0; while [ "x${VARS[count]}" != "x" ]; do
     IFS=, read -r JOBTYPE JOBNAME PARAMETER RESULT <<< "${VARS[count]}"
-    PARAMETERQUOTE="$(echo "$PARAMETER" | sed -e 's/\$//' | sed -e 's/\///' | sed -e 's/ //g' | sed -e 's/=//g' | tr '[:upper:]' '[:lower:]')"
+    PARAMETERQUOTE="$(echo "$PARAMETER" | sed -e 's/\$//g' | sed -e 's/\///g' | sed -e 's/ //g' | sed -e 's/=//g' | tr '[:upper:]' '[:lower:]')"
 	{ 	"$script_dir/plot" --parameter --outfile="$JOBTYPE-$JOBNAME-$PARAMETERQUOTE.svg" "$RESULT" "$JOBTYPE-$JOBNAME-$PARAMETERQUOTE"*csv
     	"$script_dir/plot" --parameter --outfile="$JOBTYPE-$JOBNAME-$PARAMETERQUOTE.png" "$RESULT" "$JOBTYPE-$JOBNAME-$PARAMETERQUOTE"*csv
     	"$script_dir/plot" --cost --parameter --outfile="$JOBTYPE-$JOBNAME-$PARAMETERQUOTE-cost.svg" "$RESULT" "$JOBTYPE-$JOBNAME-$PARAMETERQUOTE"*csv
@@ -173,7 +173,7 @@ fi
 if [ "$(echo "$arg" | grep cleanup)" != "" ]; then
   count=0; while [ "x${VARS[count]}" != "x" ]; do
     IFS=, read -r JOBTYPE JOBNAME PARAMETER RESULT <<< "${VARS[count]}"
-    PARAMETERQUOTE="$(echo "$PARAMETER" | sed -e 's/\$//' | sed -e 's/\///' | sed -e 's/ //g' | sed -e 's/=//g' | tr '[:upper:]' '[:lower:]')"
+    PARAMETERQUOTE="$(echo "$PARAMETER" | sed -e 's/\$//g' | sed -e 's/\///g' | sed -e 's/ //g' | sed -e 's/=//g' | tr '[:upper:]' '[:lower:]')"
     jobs="$(kubectl get jobs -n benchmark --selector=app="$JOBTYPE-$JOBNAME-$PARAMETERQUOTE" --output=jsonpath='{.items[*].metadata.name}')"
     for j in $jobs; do
       kubectl delete job -n benchmark "$j"

--- a/cluster-script/k8s-job.envsubst
+++ b/cluster-script/k8s-job.envsubst
@@ -163,6 +163,31 @@ spec:
                 cat out.json > /dev/stderr
                 tac out.json | grep -m 1 Value | cut  -d ':' -f 2 | xargs | printf '\nCSV:fortio,$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(awk "BEGIN{print "$(cat)"*1000}")"
               done
+            elif [ $JOBTYPE = wrk2-benchmark ] && [ $MODE = nginx ]; then
+              PORT=8000
+              while ! echo | nc nginx-service "$PORT"; do
+                echo "Waiting for nginx-service..."
+                sleep 1
+              done
+              while ! echo | nc nginx-service 9999 > /tmp/system-out; do
+                sleep 1
+              done
+              SYSTEM="$(cat /tmp/system-out)"
+              for i in $(seq 1 $ITERATIONS); do
+                LATENCY="$(wrk $PARAMETER -L -s /usr/local/share/wrk2/body-100-report.lua "http://nginx-service:$PORT" | tee /dev/stderr | grep 99.900% | awk '{print $2}')"
+                # cut away unit (ms or s)
+                if echo "$LATENCY" | grep ms > /dev/null; then
+                  U=m
+                else
+                  U=s
+                fi
+                LATENCY="$(echo $LATENCY | cut -d "$U" -f 1)"
+                # calculate ms if unit was s
+                if [ "$U" = s ]; then
+                  LATENCY="$(awk "BEGIN{print "$LATENCY"/1000}")"
+                fi
+                printf '\nCSV:wrk2 $MODE,$PARAMETER (req body len 100),%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$LATENCY"
+              done
             else
               echo "ERROR: Unknown mode"
               exit 1

--- a/wrk2-benchmark/Dockerfile
+++ b/wrk2-benchmark/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine as builder
+WORKDIR /usr/src
+RUN apk add --update alpine-sdk zlib-dev openssl-dev
+ADD https://github.com/kinvolk/wrk2/archive/master.zip .
+RUN unzip master.zip && \
+    cd wrk2-master && \
+    make -j && \
+    strip wrk
+
+FROM alpine
+MAINTAINER Kinvolk
+# dstat
+RUN apk add --update --no-cache py2-six
+COPY --from=dstat-builder /dstat/dstat /usr/local/bin
+COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
+# lscpu
+RUN apk add --update --no-cache util-linux
+# wrk2
+RUN apk add --update --no-cache so:libcrypto.so.1.1 so:libssl.so.1.1 so:libgcc_s.so.1
+COPY --from=builder /usr/src/wrk2-master/wrk /usr/local/bin/
+ADD body-100-report.lua /usr/local/share/wrk2/body-100-report.lua

--- a/wrk2-benchmark/body-100-report.lua
+++ b/wrk2-benchmark/body-100-report.lua
@@ -1,0 +1,11 @@
+wrk.body = "____________________________________________________________________________________________________"
+function done(summary, latency, requests)
+    print(string.format("Total Requests: %d", summary.requests))
+    print(string.format("HTTP errors: %d", summary.errors.status))
+    print(string.format("Requests timed out: %d", summary.errors.timeout))
+    print(string.format("Bytes received: %d", summary.bytes))
+    print(string.format("Socket connect errors: %d", summary.errors.connect))
+    print(string.format("Socket read errors: %d", summary.errors.read))
+    print(string.format("Socket write errors: %d", summary.errors.write))
+end
+


### PR DESCRIPTION
As with fortio a fixed server type is used as client on all clusters. Currently wrk2 requires to be run on a x86 node because it was not ported to arm64 yet (update LuaJIT, no hdr x86 intrinsics). (The name of the environment variable `FIXEDX86NODE` already reflects this.)

This benchmark container is called `wrk2-benchmark` due to a name conflict in the quay repository.