### PR TITLE
cluster-script: No network node, Do not use custom labels for nodes but k8s defaults

### DIFF
--- a/cluster-script/benchmark.sh
+++ b/cluster-script/benchmark.sh
@@ -74,11 +74,12 @@ for S in $SYSBENCH; do
   fi
   VARS+=("$(printf 'sysbench,%s,$ONE,%s' "$S" "$COL")" "$(printf 'sysbench,%s,$CORES,%s' "$S" "$COL")" "$(printf 'sysbench,%s,$CPUS,%s' "$S" "$COL")")
 done
+# Do not use CPUS and CORES here which now refer to the fixed x86 system (which may be correct but rather use fixed numbers here to avoid confusion)
 for S in $NETWORK; do
   if [ "$S" = iperf3 ]; then
-    VARS+=('iperf3,iperf3,$ONE,MBit/s' 'iperf3,iperf3,$CORES,MBit/s' 'iperf3,iperf3,$CPUS,MBit/s')
+    VARS+=('iperf3,iperf3,-P 1 -R,MBit/s' 'iperf3,iperf3,-P 28 -R,MBit/s' 'iperf3,iperf3,-P 56 -R,MBit/s')
   elif [ "$S" = ab ]; then
-    VARS+=('ab,nginx,$CORES,HTTP-Req/s' 'ab,nginx,$CPUS,HTTP-Req/s')
+    VARS+=('ab,nginx,56,HTTP-Req/s')
   elif [ "$S" = fortio ]; then
     VARS+=('fortio,fortio,-c 20 -qps=2000 -t=60s,p999 latency ms' 'fortio,fortio,-grpc -s 10 -c 20 -qps=2000 -t=60s,p999 latency ms')
   fi

--- a/cluster-script/k8s-job.envsubst
+++ b/cluster-script/k8s-job.envsubst
@@ -126,7 +126,7 @@ spec:
               done
               SYSTEM="$(cat /tmp/system-out)"
               for i in $(seq 1 $ITERATIONS); do
-                iperf3 -p "$PORT" -P $PARAMETER -c iperf3-service --time 30 -J | tee /dev/stderr | grep bits_per_second | tail -n 1 | cut -d : -f 2 | cut -d , -f 1 | cut -d . -f 1 | xargs | echo "$(( $(cat)/1000/1000 ))" | printf '\nCSV:iperf3 $MODE,streams=$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
+                iperf3 -p "$PORT" $PARAMETER -c iperf3-service --time 30 -J | tee /dev/stderr | grep bits_per_second | tail -n 1 | cut -d : -f 2 | cut -d , -f 1 | cut -d . -f 1 | xargs | echo "$(( $(cat)/1000/1000 ))" | printf '\nCSV:iperf3 $MODE,$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
               done
             elif [ $JOBTYPE = ab ] && [ $MODE = nginx ]; then
               PORT=8000

--- a/cluster-script/k8s-job.envsubst
+++ b/cluster-script/k8s-job.envsubst
@@ -121,6 +121,10 @@ spec:
                 echo "Waiting for iperf3-service..."
                 sleep 1
               done
+              while ! echo | nc iperf3-service 9999 > /tmp/system-out; do
+                sleep 1
+              done
+              SYSTEM="$(cat /tmp/system-out)"
               for i in $(seq 1 $ITERATIONS); do
                 iperf3 -p "$PORT" -P $PARAMETER -c iperf3-service --time 30 -J | tee /dev/stderr | grep bits_per_second | tail -n 1 | cut -d : -f 2 | cut -d , -f 1 | cut -d . -f 1 | xargs | echo "$(( $(cat)/1000/1000 ))" | printf '\nCSV:iperf3 $MODE,streams=$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
               done
@@ -130,6 +134,10 @@ spec:
                 echo "Waiting for nginx-service..."
                 sleep 1
               done
+              while ! echo | nc nginx-service 9999 > /tmp/system-out; do
+                sleep 1
+              done
+              SYSTEM="$(cat /tmp/system-out)"
               for i in $(seq 1 $ITERATIONS); do
                 ab -c $PARAMETER -t 30 -n 999999999 http://nginx-service:8000/ 2>&1 | tee /dev/stderr | grep 'Requests per second' | awk '{print $4}' | printf '\nCSV:ab $MODE,connections=$PARAMETER,%s,%s,$ID,$COST,$META\n' "$SYSTEM" "$(cat)"
               done

--- a/cluster-script/k8s-job.envsubst
+++ b/cluster-script/k8s-job.envsubst
@@ -25,7 +25,7 @@ spec:
           defaultMode: 0777
       nodeSelector:
         kubernetes.io/arch: $ARCH
-        benchmark-node: $BENCHNODESELECTOR
+        kubernetes.io/hostname: $BENCHNODESELECTOR
       containers:
       - name: cont
         resources:

--- a/cluster-script/network-server.envsubst
+++ b/cluster-script/network-server.envsubst
@@ -35,7 +35,7 @@ spec:
           defaultMode: 0777
       nodeSelector:
         kubernetes.io/arch: $ARCH
-        benchmark-node: $NETNODESELECTOR
+        kubernetes.io/hostname: $NETNODESELECTOR
       containers:
       - name: cont
         resources:

--- a/cluster-script/run-for-list.sh
+++ b/cluster-script/run-for-list.sh
@@ -6,7 +6,7 @@ if [ "$#" != 2 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   echo "Runs 'benchmark.sh ARG' for each cluster entry in FILE."
   echo "FILE contains one cluster entry per line, stored as comma-separated values"
   echo "(no whitespaces before or after comma) in the following order:"
-  echo "KUBECONFIG,ARCH,COST,META,ITERATIONS,BENCHMARKNODE,NETWORKNODE,FIXEDX86NODE"
+  echo "KUBECONFIG,ARCH,COST,META,ITERATIONS,BENCHMARKNODE,FIXEDX86NODE"
   echo "The values are used as env vars for benchmark.sh."
   echo "A final 'benchmark.sh plot' run is done if 'gather' is part of ARG."
   echo
@@ -22,8 +22,8 @@ P="$(dirname "$(readlink -f $(which "$0"))")"
 
 WAIT=""
 while IFS= read -r line || [ -n "$line" ]; do
-  IFS=, read KUBECONFIG ARCH COST META ITERATIONS BENCHMARKNODE NETWORKNODE FIXEDX86NODE <<< "$line"
-  export KUBECONFIG ARCH COST META ITERATIONS BENCHMARKNODE NETWORKNODE FIXEDX86NODE
+  IFS=, read KUBECONFIG ARCH COST META ITERATIONS BENCHMARKNODE FIXEDX86NODE <<< "$line"
+  export KUBECONFIG ARCH COST META ITERATIONS BENCHMARKNODE FIXEDX86NODE
   "$P/benchmark.sh" "$ARG" &
   WAIT+="$! "
   if [ "$ARG" = plot ]; then


### PR DESCRIPTION
**No network node:**
Spares one node per cluster and gives results that are also comparable but from the view point of an external client.
_How to test:_
Change the input list as follows:
```
…/packet-lokomotive-intel/assets/auth/kubeconfig,amd64,2.0,ewr1,1,k-xeon-he-worker-0,k-xeon-he-worker-1
…/packet-lokomotive-amd/assets/auth/kubeconfig,amd64,1.0,ewr1,1,k-epyc-he-worker-0,k-epyc-x86-worker-0
…/packet-lokomotive-arm/assets/auth/kubeconfig,arm64,1.0,sjc1,1,k-test-he-worker-0,k-test-x86-worker-0
```

**Do not use custom labels:**
This is one requirement to run the benchmark in parallel on a hybrid
cluster because currently two nodes cannot have the same label at the
same time. This problem is avoided by using the hostname labels set
up by k8s.