### PR TITLE
cluster-terraform: Add terraform code for preconfigured clusters

### DIFF
--- a/cluster-terraform/amd.tf
+++ b/cluster-terraform/amd.tf
@@ -1,0 +1,76 @@
+module "controller-amd" {
+  source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes?ref=27f1405662fec5232ad407262fa54b9ebebf2edc"
+
+  providers = {
+    aws      = "aws.default"
+    local    = "local.default"
+    null     = "null.default"
+    template = "template.default"
+    tls      = "tls.default"
+    packet   = "packet.default"
+  }
+
+  dns_zone    = "${var.dns_zone}"
+  dns_zone_id = "${var.dns_zone_id}"
+
+  ssh_keys = "${var.ssh_keys}"
+
+  asset_dir = "./assets-amd"
+
+  cluster_name = "amd"
+  project_id   = "${var.project_id}"
+  facility     = "sjc1"
+
+  controller_count = 1
+  controller_type  = "c2.medium.x86"
+
+  management_cidrs = ["0.0.0.0/0"]
+
+  node_private_cidr = "10.0.0.0/8"
+}
+
+module "worker-amd" {
+  source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes/workers?ref=27f1405662fec5232ad407262fa54b9ebebf2edc"
+
+  providers = {
+    local    = "local.default"
+    template = "template.default"
+    tls      = "tls.default"
+    packet   = "packet.default"
+  }
+
+  ssh_keys = "${var.ssh_keys}"
+
+  cluster_name = "amd"
+  project_id   = "${var.project_id}"
+  facility     = "sjc1"
+  pool_name    = "pool"
+
+  count = 1
+  type  = "c2.medium.x86"
+
+  kubeconfig = "${module.controller-amd.kubeconfig}"
+}
+
+module "worker-amd-x86client" {
+  source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes/workers?ref=27f1405662fec5232ad407262fa54b9ebebf2edc"
+
+  providers = {
+    local    = "local.default"
+    template = "template.default"
+    tls      = "tls.default"
+    packet   = "packet.default"
+  }
+
+  ssh_keys = "${var.ssh_keys}"
+
+  cluster_name = "amd"
+  project_id   = "${var.project_id}"
+  facility     = "sjc1"
+  pool_name    = "x86client"
+
+  count = 1
+  type  = "m2.xlarge.x86"
+
+  kubeconfig = "${module.controller-amd.kubeconfig}"
+}

--- a/cluster-terraform/ampere.tf
+++ b/cluster-terraform/ampere.tf
@@ -1,0 +1,82 @@
+module "controller-ampere" {
+  source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes?ref=27f1405662fec5232ad407262fa54b9ebebf2edc"
+
+  providers = {
+    aws      = "aws.default"
+    local    = "local.default"
+    null     = "null.default"
+    template = "template.default"
+    tls      = "tls.default"
+    packet   = "packet.default"
+  }
+
+  dns_zone    = "${var.dns_zone}"
+  dns_zone_id = "${var.dns_zone_id}"
+
+  ssh_keys = "${var.ssh_keys}"
+
+  asset_dir = "./assets-ampere"
+
+  cluster_name = "ampere"
+  project_id   = "${var.project_id}"
+  facility     = "sjc1"
+
+  controller_count = 1
+  controller_type  = "c2.large.arm"
+  os_arch = "arm64"
+  os_channel = "alpha"
+  ipxe_script_url = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/arm64-usr/packet.ipxe"
+
+  management_cidrs = ["0.0.0.0/0"]
+
+  node_private_cidr = "10.0.0.0/8"
+}
+
+module "worker-ampere" {
+  source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes/workers?ref=27f1405662fec5232ad407262fa54b9ebebf2edc"
+
+  providers = {
+    local    = "local.default"
+    template = "template.default"
+    tls      = "tls.default"
+    packet   = "packet.default"
+  }
+
+  ssh_keys = "${var.ssh_keys}"
+
+  cluster_name = "ampere"
+  project_id   = "${var.project_id}"
+  facility     = "sjc1"
+  pool_name    = "pool"
+
+  count = 1
+  type  = "c2.large.arm"
+  ipxe_script_url = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/arm64-usr/packet.ipxe"
+  os_arch = "arm64"
+  os_channel = "alpha"
+
+  kubeconfig = "${module.controller-ampere.kubeconfig}"
+}
+
+module "worker-ampere-x86client" {
+  source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes/workers?ref=27f1405662fec5232ad407262fa54b9ebebf2edc"
+
+  providers = {
+    local    = "local.default"
+    template = "template.default"
+    tls      = "tls.default"
+    packet   = "packet.default"
+  }
+
+  ssh_keys = "${var.ssh_keys}"
+
+  cluster_name = "ampere"
+  project_id   = "${var.project_id}"
+  facility     = "sjc1"
+  pool_name    = "x86client"
+
+  count = 1
+  type  = "m2.xlarge.x86"
+
+  kubeconfig = "${module.controller-ampere.kubeconfig}"
+}

--- a/cluster-terraform/intel.tf
+++ b/cluster-terraform/intel.tf
@@ -1,0 +1,76 @@
+module "controller-intel" {
+  source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes?ref=27f1405662fec5232ad407262fa54b9ebebf2edc"
+
+  providers = {
+    aws      = "aws.default"
+    local    = "local.default"
+    null     = "null.default"
+    template = "template.default"
+    tls      = "tls.default"
+    packet   = "packet.default"
+  }
+
+  dns_zone    = "${var.dns_zone}"
+  dns_zone_id = "${var.dns_zone_id}"
+
+  ssh_keys = "${var.ssh_keys}"
+
+  asset_dir = "./assets-intel"
+
+  cluster_name = "intel"
+  project_id   = "${var.project_id}"
+  facility     = "sjc1"
+
+  controller_count = 1
+  controller_type  = "m2.xlarge.x86"
+
+  management_cidrs = ["0.0.0.0/0"]
+
+  node_private_cidr = "10.0.0.0/8"
+}
+
+module "worker-intel" {
+  source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes/workers?ref=27f1405662fec5232ad407262fa54b9ebebf2edc"
+
+  providers = {
+    local    = "local.default"
+    template = "template.default"
+    tls      = "tls.default"
+    packet   = "packet.default"
+  }
+
+  ssh_keys = "${var.ssh_keys}"
+
+  cluster_name = "intel"
+  project_id   = "${var.project_id}"
+  facility     = "sjc1"
+  pool_name    = "pool"
+
+  count = 1
+  type  = "m2.xlarge.x86"
+
+  kubeconfig = "${module.controller-intel.kubeconfig}"
+}
+
+module "worker-intel-x86client" {
+  source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes/workers?ref=27f1405662fec5232ad407262fa54b9ebebf2edc"
+
+  providers = {
+    local    = "local.default"
+    template = "template.default"
+    tls      = "tls.default"
+    packet   = "packet.default"
+  }
+
+  ssh_keys = "${var.ssh_keys}"
+
+  cluster_name = "intel"
+  project_id   = "${var.project_id}"
+  facility     = "sjc1"
+  pool_name    = "x86client"
+
+  count = 1
+  type  = "m2.xlarge.x86"
+
+  kubeconfig = "${module.controller-intel.kubeconfig}"
+}

--- a/cluster-terraform/provider.tf
+++ b/cluster-terraform/provider.tf
@@ -1,0 +1,34 @@
+provider "aws" {
+  version = "~> 2.31.0"
+  alias   = "default"
+}
+
+provider "ct" {
+  version = "0.4.0"
+}
+
+provider "local" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+provider "null" {
+  version = "~> 2.1"
+  alias   = "default"
+}
+
+provider "template" {
+  version = "~> 2.1"
+  alias   = "default"
+}
+
+provider "tls" {
+  version = "~> 2.0"
+  alias   = "default"
+}
+
+provider "packet" {
+  version = "~> 1.2"
+  alias   = "default"
+}
+

--- a/cluster-terraform/variables.tf
+++ b/cluster-terraform/variables.tf
@@ -1,0 +1,18 @@
+variable "ssh_keys" {
+  type        = "list"
+  description = "A list of public SSH keys to authorize on the VPN host on Packet"
+}
+
+variable "dns_zone" {
+  type        = "string"
+  description = "AWS Route53 DNS Zone (e.g. aws.example.com)"
+}
+
+variable "dns_zone_id" {
+  type        = "string"
+  description = "AWS Route53 DNS Zone ID (e.g. Z3PAABBCFAKEC0)"
+}
+
+variable "project_id" {
+  description = "Packet project ID (e.g. 405efe9c-cce9-4c71-87c1-949c290b27dc)"
+}


### PR DESCRIPTION
Instead of referring to the generic Lokomotive documentation, provide Terraform code to provision the three benchmark clusters.