### PR TITLE
Refactor the benchmark containers to simplify usage

### DIFF
--- a/ab/Dockerfile
+++ b/ab/Dockerfile
@@ -3,3 +3,15 @@ MAINTAINER Kinvolk
 
 # ab
 RUN apk add --update --no-cache apache2-utils
+
+# nginx serving 404 on port 8000 running as benchmark user (switches if started as root)
+RUN apk add --update --no-cache nginx
+RUN adduser -u 1000 -D benchmark
+RUN sed -i 's/user nginx;/user benchmark;/g' /etc/nginx/nginx.conf
+RUN sed -i 's/80 default_server/8000 default_server/g' /etc/nginx/conf.d/default.conf
+RUN mkdir /run/nginx
+RUN chown benchmark:benchmark -R /var/lib/nginx /run/nginx/ /var/log/nginx
+
+# Runnable scripts
+COPY run-benchmark.sh /usr/local/bin/run-benchmark.sh
+COPY run-server.sh /usr/local/bin/run-server.sh

--- a/ab/Dockerfile
+++ b/ab/Dockerfile
@@ -1,10 +1,5 @@
-FROM alpine
+FROM benchmark-base
 MAINTAINER Kinvolk
-# dstat
-RUN apk add --update --no-cache py2-six
-COPY --from=dstat-builder /dstat/dstat /usr/local/bin
-COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
-# lscpu
-RUN apk add --update --no-cache util-linux
+
 # ab
 RUN apk add --update --no-cache apache2-utils

--- a/ab/run-benchmark.sh
+++ b/ab/run-benchmark.sh
@@ -1,0 +1,74 @@
+# This script has no hashbang as it's intended to run on systems with ash or
+# bash, including busybox.
+set -eu
+
+. /usr/local/bin/output.sh
+
+usage() {
+  cat <<EOF
+Usage: run-benchmark.sh [-h] [-v] [-T target_host] [-t threads]
+                        $(output_options_short)
+
+Run the ab benchmark
+
+Available options:
+
+-h, --help       Print this help and exit
+-v, --verbose    Print script debug info
+-T, --target     Name of the host to target for the benchmark (default: nginx-service)
+-t, --threads    Thread concurrency to use when calling ab
+$(output_options_long)
+EOF
+  exit
+}
+
+parse_params() {
+  RESULT="HTTP-Req/s"
+  TARGET="nginx-service"
+  THREADS=1
+
+  parse_output_params "$@"
+  set -- $UNPARSED
+
+  while [ $# -gt 0 ]; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -v | --verbose) set -x ;;
+    -T | --target)
+      TARGET="${2-}"
+      shift
+      ;;
+    -t | --threads)
+      THREADS="${2-}"
+      shift
+      ;;
+    *) ;; # Skip unknown params
+    esac
+    shift
+  done
+}
+
+parse_params "$@"
+
+PORT=8000
+MODE=nginx
+
+while ! echo | nc "$TARGET" "$PORT"; do
+  echo "Waiting for $TARGET:$PORT..."
+  sleep 1
+done
+
+while ! echo | nc "$TARGET" 9999 > /tmp/system-out; do
+  sleep 1
+done
+
+SYSTEM="$(cat /tmp/system-out)"
+BENCHMARK_NAME="ab $MODE"
+PARAMS="connections=$THREADS"
+
+output_header
+
+for i in $(seq 1 $ITERATIONS); do
+  VALUE=$(ab -c $THREADS -t 30 -n 999999999 http://$TARGET:8000/ 2>&1 | tee /dev/stderr | grep 'Requests per second' | awk '{print $4}')
+  output_line "$VALUE"
+done

--- a/ab/run-server.sh
+++ b/ab/run-server.sh
@@ -1,0 +1,10 @@
+set -eu
+
+SYSTEM=$(/usr/local/bin/cpu.sh system)
+echo "$SYSTEM"
+
+printf '#!/bin/sh\necho "%s"' "$SYSTEM" > /tmp/system
+chmod +x /tmp/system
+nc -lk -p 9999 -e /tmp/system &
+
+nginx -g "daemon off;"

--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,9 @@ done
 echo "#############  Building dependencies - dstat ###############"
 docker build -t dstat-builder "${build_root}/dstat"
 
+echo "############# Building base container ###############"
+docker build -t benchmark-base "${build_root}/common"
+
 echo "#############  Building: $targets  ###############"
 
 for t in $targets; do

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -1,0 +1,15 @@
+# This container is the basis for all the other benchmark containers.
+
+FROM alpine
+MAINTAINER Kinvolk
+
+# dstat
+COPY --from=dstat-builder /dstat/dstat /usr/local/bin
+COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
+
+# lscpu
+RUN apk add --update --no-cache util-linux
+
+# Common script
+COPY cpu.sh /usr/local/bin/cpu.sh
+COPY output.sh /usr/local/bin/output.sh

--- a/common/cpu.sh
+++ b/common/cpu.sh
@@ -1,0 +1,95 @@
+# Please note that we consciously do not define a hashbang interpreter here
+# so the script works on systems that only ship either ash or bash.
+
+# Prints the CPU architecture to stdout.
+# (either "arm64" or "amd64")
+function get_arch() {
+    local a=$(lscpu | awk '/^Architecture:/ {print $2}')
+    case $a in
+        aarch64) a="arm64";;
+        x86_64)  a="amd64";;
+    esac
+    echo $a
+}
+
+# Prints the number of (hyperthreaded or physical) CPUs currently online to
+# stdout.
+function _get_online() {
+    # format is e.g.:  1-3,9,15,20-27
+    lscpu | sed -n 's/^On-line CPU(s) list:[[:space:]]*//p'
+}
+
+function _calc_sums() {
+    # calculate intermediate sums, e.g. "1-3,9,15,20-27" => "3 1 1 8"
+    local r=""
+    for r in $(_get_online | sed 's/,/ /g'); do
+        echo "$r" | sed 's/-/ /' | \
+            { read a b
+              if [ -n "$b" ] ; then
+                 # it's a range, e.g. 1-3
+                 echo "$((b+1 - a))"
+              else
+                 # a single cpu (so its "sum" is 1)
+                 echo "1"
+              fi; }
+     done
+}
+
+function get_num_cpus() {
+    local sums=$(_calc_sums)
+    # replace spaces with "+" ("3 1 1 8" => "3+1+1+8"), calculate final sum
+    echo $(( $(echo $sums | sed 's/ /+/g') ))
+}
+
+# Prints hyperthreading status ("on" or "off") to stdout
+function get_ht() {
+    lscpu | awk \
+      '/^Thread\(s\) per core:/ {if ($4 > 1) print "on"; else print "off"; }'
+}
+
+# Prints number of physical cores
+function get_num_cores() {
+    get_ht | grep -q "off" && { get_num_cpus; return; }
+    lscpu -p \
+            | sed -n 's/^[0-9]\+,\([0-9]\+,[0-9]\+\),.*/\1/p' \
+            | sort | uniq | wc -l
+}
+
+# Prints number of sockets
+function get_num_sockets() {
+    lscpu | awk '/^Socket\(s\):/ {print $2 }'
+}
+
+# Prints CPU manufacturer / Model name & revision
+function get_model() {
+    lscpu | awk '/^Vendor ID:/  { $1=""; $2="";
+                                    gsub(/^ +/,"" );
+                                    gsub(/ +$/,"");
+                                    s=$0 }
+                 /^Model name:/ { $1=""; $2="";
+                                    gsub(/^ +/,"");
+                                    gsub(/ +$/,"");
+                                    s=s " " $0 }
+                     END { if (s == "APM X-Gene") s="Ampere eMAG";
+                                    print s }'
+}
+
+function get_system() {
+    CPU=$(get_model)
+    SOCKETS=$(get_num_sockets)
+    CPUS=$(get_num_cpus)
+    CORES=$(get_num_cores)
+    HT=$(get_ht)
+    echo "$CPU (Sockets: $SOCKETS. CPUs: $CPUS. Cores: $CORES. HT: $HT)"
+}
+
+case $1 in
+   arch) get_arch;;
+   cpus) get_num_cpus;;
+   ht) get_ht;;
+   cores) get_num_cores;;
+   sockets) get_num_sockets;;
+   model) get_model;;
+   system) get_system;;
+   *) echo "Unknown argument '$1'" >&2;;
+esac

--- a/common/output.sh
+++ b/common/output.sh
@@ -1,0 +1,66 @@
+# This script has no hashbang as it's intended to run on systems with ash or
+# bash, including busybox.
+set -eu
+
+output_options_short() {
+  echo "[-i iterations] [-r result] [-j job_id] [-c cost] [-m metadata]"
+}
+
+output_options_long() {
+  cat <<EOF
+-i, --iterations Number of iterations to run
+-r, --result     Name of the result column
+-j, --job-id     Job identifier
+-c, --cost       Cost/hour value
+-m, --metadata   Metadata related to the benchmark
+EOF
+  exit
+}
+
+parse_output_params() {
+  ITERATIONS=1
+  RESULT="${RESULT-}"
+  ID=""
+  COST=""
+  META=""
+  UNPARSED=""
+
+  while [ $# -gt 0 ]; do
+    case "${1-}" in
+    -i | --iterations)
+      ITERATIONS="${2-}"
+      shift
+      ;;
+    -r | --result)
+      RESULT="${2-}"
+      shift
+      ;;
+    -j | --job-id)
+      ID="${2-}"
+      shift
+      ;;
+    -c | --cost)
+      COST="${2-}"
+      shift
+      ;;
+    -m | --metadata)
+      META="${2-}"
+      shift
+      ;;
+    *) # Keep unknown params to have them be parsed by other functions
+      UNPARSED="$UNPARSED $1"
+      ;;
+    esac
+    shift
+  done
+}
+
+output_header() {
+  echo
+  echo "CSV:Name,Parameter,System,$RESULT,Job,Cost,Meta"
+}
+
+output_line() {
+  VALUE=$1
+  echo "CSV:$BENCHMARK_NAME,$PARAMS,$SYSTEM,$VALUE,$ID,$COST,$META"
+}

--- a/dstat/Dockerfile
+++ b/dstat/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine as dstat-builder
 MAINTAINER Kinvolk
-RUN apk add --update git
+RUN apk add --update git patch
 RUN cd / && git clone https://github.com/dagwieers/dstat.git
 COPY ./dstat-types.patch /dstat/dstat-types.patch 
 RUN cd /dstat && \

--- a/fortio/Dockerfile
+++ b/fortio/Dockerfile
@@ -6,3 +6,10 @@ MAINTAINER Kinvolk
 
 # fortio
 COPY --from=builder /go/bin/fortio /usr/local/bin/fortio
+
+# The benchmark uses jq to parse the JSON output
+RUN apk add --update --no-cache jq
+
+# Runnable scripts
+COPY run-benchmark.sh /usr/local/bin/run-benchmark.sh
+COPY run-server.sh /usr/local/bin/run-server.sh

--- a/fortio/Dockerfile
+++ b/fortio/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:alpine as builder
-RUN apk add --update git
 RUN go get fortio.org/fortio
 
 FROM benchmark-base
@@ -7,4 +6,3 @@ MAINTAINER Kinvolk
 
 # fortio
 COPY --from=builder /go/bin/fortio /usr/local/bin/fortio
-COPY --from=builder /go/src/fortio.org /go/src/fortio.org

--- a/fortio/Dockerfile
+++ b/fortio/Dockerfile
@@ -2,14 +2,9 @@ FROM golang:alpine as builder
 RUN apk add --update git
 RUN go get fortio.org/fortio
 
-FROM alpine
+FROM benchmark-base
 MAINTAINER Kinvolk
-# dstat
-RUN apk add --update --no-cache py2-six
-COPY --from=dstat-builder /dstat/dstat /usr/local/bin
-COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
-# lscpu
-RUN apk add --update --no-cache util-linux
+
 # fortio
 COPY --from=builder /go/bin/fortio /usr/local/bin/fortio
 COPY --from=builder /go/src/fortio.org /go/src/fortio.org

--- a/fortio/run-benchmark.sh
+++ b/fortio/run-benchmark.sh
@@ -1,0 +1,97 @@
+# This script has no hashbang as it's intended to run on systems with ash or
+# bash, including busybox.
+set -eu
+
+. /usr/local/bin/output.sh
+
+usage() {
+  cat <<EOF
+Usage: run-benchmark.sh [-h] [-v] [-T target_host] [-t threads] [-d duration] [--grpc]
+                        $(output_options_short)
+
+Run the fortio benchmark
+
+Available options:
+
+-h, --help       Print this help and exit
+-v, --verbose    Print script debug info
+-T, --target     Name of the host to target for the benchmark (default: fortio-service)
+-t, --threads    Amount of threads to use
+-d, --duration   Time window to use for the benchmark (default: 60s)
+-g, --grpc       Use GRPC for the benchmark
+$(output_options_long)
+EOF
+  exit
+}
+
+parse_params() {
+  RESULT="p999 latency ms"
+  TARGET="fortio-service"
+  THREADS=1
+  DURATION="60s"
+  GRPC="0"
+
+  parse_output_params "$@"
+  set -- $UNPARSED
+
+  while [ $# -gt 0 ]; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -v | --verbose) set -x ;;
+    -T | --target)
+      TARGET="${2-}"
+      shift
+      ;;
+    -t | --threads)
+      THREADS="${2-}"
+      shift
+      ;;
+    -d | --duration)
+      DURATION="${2-}"
+      shift
+      ;;
+    -g | --grpc)
+      GRPC="1"
+      ;;
+    *) ;; # Skip unknown params
+    esac
+    shift
+  done
+}
+
+parse_params "$@"
+
+cd /tmp
+if [ $GRPC = "1" ]; then
+  PORT=8079
+  PARAMS="-grpc -s 10 "
+else
+  PORT=8080
+  PARAMS=""
+fi
+
+while ! echo | nc "$TARGET" "$PORT"; do
+  echo "Waiting for $TARGET:$PORT to be ready..."
+  sleep 1
+done
+
+while ! echo | nc "$TARGET" 9999 > /tmp/system-out; do
+  sleep 1
+done
+
+SYSTEM="$(cat /tmp/system-out)"
+BENCHMARK_NAME="fortio"
+PARAMS="$PARAMS-c $THREADS -t=$DURATION -qps=2000"
+
+output_header
+
+for i in $(seq 1 $ITERATIONS); do
+  REQ_BODY_LEN=50
+  rm out.json || true
+  fortio load $PARAMS -payload-size=50 -keepalive=false \
+          -labels='-payload-size=50 -keepalive=false $PARAMS Iteration: '"$i" \
+          -json=out.json "http://$TARGET:$PORT"
+  cat out.json > /dev/stderr
+  VALUE=$(cat /tmp/out.json | jq '.DurationHistogram.Percentiles[-1].Value*1000')
+  output_line "$VALUE"
+done

--- a/fortio/run-server.sh
+++ b/fortio/run-server.sh
@@ -1,0 +1,10 @@
+set -eu
+
+SYSTEM=$(/usr/local/bin/cpu.sh system)
+echo "$SYSTEM"
+
+printf '#!/bin/sh\necho "%s"' "$SYSTEM" > /tmp/system
+chmod +x /tmp/system
+nc -lk -p 9999 -e /tmp/system &
+
+fortio server -ui-path ''

--- a/iperf3/Dockerfile
+++ b/iperf3/Dockerfile
@@ -9,13 +9,9 @@ RUN tar xzf ${IPERF_VER}.tar.gz && \
     ./configure --disable-profiling && \
     make -j install DESTDIR=/iperf3
 
-
-FROM alpine
+FROM benchmark-base
 MAINTAINER Kinvolk
-# dstat
-RUN apk add --update --no-cache py2-six
-COPY --from=dstat-builder /dstat/dstat /usr/local/bin
-COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
+
 # iperf3
-RUN apk add --update --no-cache util-linux openssl
+RUN apk add --update --no-cache openssl
 COPY --from=builder /iperf3/ /

--- a/iperf3/Dockerfile
+++ b/iperf3/Dockerfile
@@ -15,3 +15,10 @@ MAINTAINER Kinvolk
 # iperf3
 RUN apk add --update --no-cache openssl
 COPY --from=builder /iperf3/ /
+
+# The benchmark uses jq to parse the JSON output
+RUN apk add --update --no-cache jq
+
+# Runnable scripts
+COPY run-benchmark.sh /usr/local/bin/run-benchmark.sh
+COPY run-server.sh /usr/local/bin/run-server.sh

--- a/iperf3/run-benchmark.sh
+++ b/iperf3/run-benchmark.sh
@@ -1,0 +1,74 @@
+# This script has no hashbang as it's intended to run on systems with ash or
+# bash, including busybox.
+set -eu
+
+. /usr/local/bin/output.sh
+
+usage() {
+  cat <<EOF
+Usage: run-benchmark.sh [-h] [-v] [-T target_host] [-t threads]
+                        $(output_options_short)
+
+Run the iperf3 benchmark
+
+Available options:
+
+-h, --help       Print this help and exit
+-v, --verbose    Print script debug info
+-T, --target     Name of the host to target for the benchmark (default: iperf3-service)
+-t, --threads    Number of parallel concurrent streams to run
+$(output_options_long)
+EOF
+  exit
+}
+
+parse_params() {
+  RESULT="MBit/s"
+  TARGET="iperf3-service"
+  THREADS=1
+
+  parse_output_params "$@"
+  set -- $UNPARSED
+
+  while [ $# -gt 0 ]; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -v | --verbose) set -x ;;
+    -T | --target)
+      TARGET="${2-}"
+      shift
+      ;;
+    -t | --threads)
+      THREADS="${2-}"
+      shift
+      ;;
+    *) ;; # Skip unknown params
+    esac
+    shift
+  done
+}
+
+parse_params "$@"
+
+PORT=6000
+MODE=nginx
+
+while ! echo | nc "$TARGET" "$PORT"; do
+  echo "Waiting for $TARGET:$PORT..."
+  sleep 1
+done
+
+while ! echo | nc "$TARGET" 9999 > /tmp/system-out; do
+  sleep 1
+done
+
+SYSTEM="$(cat /tmp/system-out)"
+BENCHMARK_NAME="iperf3 $MODE"
+PARAMS="$THREADS"
+
+output_header
+
+for i in $(seq 1 $ITERATIONS); do
+  VALUE=$(iperf3 -p "$PORT" -P $THREADS -R -c $TARGET --time 30 -J | tee /dev/stderr | jq '.end.sum_received.bits_per_second/(1000*1000)')
+  output_line "$VALUE"
+done

--- a/iperf3/run-server.sh
+++ b/iperf3/run-server.sh
@@ -1,0 +1,11 @@
+set -eu
+
+SYSTEM=$(/usr/local/bin/cpu.sh system)
+echo "$SYSTEM"
+
+printf '#!/bin/sh\necho "%s"' "$SYSTEM" > /tmp/system
+chmod +x /tmp/system
+nc -lk -p 9999 -e /tmp/system &
+
+iperf3 -s -p 6000
+

--- a/memtier/Dockerfile
+++ b/memtier/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine as builder
 MAINTAINER Kinvolk
 WORKDIR /usr/src/memcached
-ENV MEMCACHE_VER=1.5.19
+ENV MEMCACHE_VER=1.6.9
 ADD https://github.com/memcached/memcached/archive/${MEMCACHE_VER}.tar.gz .
-RUN apk add --update alpine-sdk autoconf automake pcre-dev libevent-dev zlib-dev linux-headers
+RUN apk add --update alpine-sdk autoconf automake pcre-dev libevent-dev zlib-dev linux-headers openssl-dev
 RUN tar xzf ${MEMCACHE_VER}.tar.gz &&\
     cd memcached-${MEMCACHE_VER} && \
     ./autogen.sh && \
@@ -12,15 +12,15 @@ RUN tar xzf ${MEMCACHE_VER}.tar.gz &&\
     make DESTDIR=/memcached install
 
 WORKDIR /usr/src/redis
-ENV REDIS_VER=5.0.6
-ADD https://github.com/antirez/redis/archive/${REDIS_VER}.tar.gz .
+ENV REDIS_VER=6.0.11
+ADD https://github.com/redis/redis/archive/${REDIS_VER}.tar.gz .
 RUN tar xzf ${REDIS_VER}.tar.gz && \
     cd redis-${REDIS_VER} && \
     make -j && \
     make PREFIX=/redis/usr install
 
 WORKDIR /usr/src/memtier
-ENV MEMTIER_VER=1.2.17
+ENV MEMTIER_VER=1.3.0
 ADD https://github.com/RedisLabs/memtier_benchmark/archive/${MEMTIER_VER}.tar.gz .
 RUN tar xzf ${MEMTIER_VER}.tar.gz && \
     cd memtier_benchmark-${MEMTIER_VER} && \

--- a/memtier/Dockerfile
+++ b/memtier/Dockerfile
@@ -29,15 +29,9 @@ RUN tar xzf ${MEMTIER_VER}.tar.gz && \
      make -j && \
      make DESTDIR=/memtier install
 
-
-FROM alpine
+FROM benchmark-base
 MAINTAINER Kinvolk
-# dstat
-RUN apk add --update --no-cache py2-six
-COPY --from=dstat-builder /dstat/dstat /usr/local/bin
-COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
-# lscpu
-RUN apk add --update --no-cache util-linux
+
 # memcached, redis, memtier
 RUN apk add --update --no-cache pcre libevent zlib so:libstdc++.so.6 so:libgcc_s.so.1
 COPY --from=builder /memcached/ /

--- a/memtier/Dockerfile
+++ b/memtier/Dockerfile
@@ -38,3 +38,7 @@ COPY --from=builder /memcached/ /
 COPY --from=builder /redis/ /
 COPY --from=builder /memtier/ /
 RUN adduser -u 1000 -D benchmark
+
+# Runnable scripts
+COPY run-benchmark.sh /usr/local/bin/run-benchmark.sh
+COPY run-server.sh /usr/local/bin/run-server.sh

--- a/memtier/run-benchmark.sh
+++ b/memtier/run-benchmark.sh
@@ -1,0 +1,100 @@
+# This script has no hashbang as it's intended to run on systems with ash or
+# bash, including busybox.
+set -eu
+
+. /usr/local/bin/output.sh
+
+usage() {
+  cat <<EOF
+Usage: run-benchmark.sh [-h] [-v] [-y benchmark_type] [-t threads]
+                        $(output_options_short)
+
+Run the memtier benchmark
+
+Available options:
+
+-h, --help       Print this help and exit
+-v, --verbose    Print script debug info
+-y, --type       Type of benchmark to run (memcached, redis)
+-t, --threads    Amount of threads to use for the benchmark (default: 1)
+$(output_options_long)
+EOF
+  exit
+}
+
+parse_params() {
+  RESULT="Total ops/sec"
+  TYPE="memcached"
+  THREADS=1
+
+  parse_output_params "$@"
+  set -- $UNPARSED
+
+  while [ $# -gt 0 ]; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -v | --verbose) set -x ;;
+    -y | --type)
+      TYPE="${2-}"
+      shift
+      ;;
+    -t | --threads)
+      THREADS="${2-}"
+      shift
+      ;;      
+    *) ;; # Skip unknown params
+    esac
+    shift
+  done
+}
+
+parse_params "$@"
+
+cd /tmp
+PORT=7000
+
+if [ "$TYPE" = "memcached" ]; then
+  BENCHMARKTHREADS="$THREADS"
+  BENCHMARKPROCESSES=1
+  CONCURRENCYTYPE=threads
+  PROTOCOL=memcache_binary
+  memcached --port "$(( PORT + 1 ))" -u "$(whoami)" -t "$THREADS" &
+else
+  BENCHMARKTHREADS=1
+  BENCHMARKPROCESSES="$THREADS"
+  CONCURRENCYTYPE=processes
+  PROTOCOL=redis
+  for P in $(seq 1 $BENCHMARKPROCESSES); do
+    redis-server --port "$(( PORT + P ))" &
+  done
+fi
+
+echo "Using $THREADS $CONCURRENCYTYPE for the database"
+for P in $(seq 1 $BENCHMARKPROCESSES); do
+  while [ "$(wget "http://127.0.0.1:$(( PORT + P ))" 2>&1 | grep "Connection refused")" != "" ]; do
+    sleep 1
+    echo "Waiting for DB $P to start..."
+  done
+done
+
+SYSTEM=$(/usr/local/bin/cpu.sh system)
+BENCHMARK_NAME="memtier $TYPE"
+PARAMS="$CONCURRENCYTYPE=$THREADS"
+output_header
+
+echo "Using $BENCHMARKPROCESSES processes and $BENCHMARKTHREADS threads for the benchmark client"
+for I in $(seq 1 $ITERATIONS); do
+  WAIT=""
+  for P in $(seq 1 $BENCHMARKPROCESSES); do
+    { memtier_benchmark -p "$(( PORT + P ))" -P "$PROTOCOL" -t "$BENCHMARKTHREADS" --test-time 30 --ratio 1:1 -c 25 -x 1 --data-size-range=10240-1048576 --key-pattern S:S  2>&1 | tee /dev/stderr | grep Totals | tail -n 1 | awk '{print $2}' | cut -d . -f 1 > "$P" ; } &
+    WAIT="$WAIT""$! "
+  done
+  wait $WAIT
+  SUM=0
+  for P in $(cat $(seq 1 $BENCHMARKPROCESSES)); do
+    SUM="$(( SUM + P ))"
+  done
+  output_line "$SUM"
+done
+
+killall redis-server memcached || true

--- a/memtier/run-server.sh
+++ b/memtier/run-server.sh
@@ -1,0 +1,10 @@
+set -eu
+
+SYSTEM=$(/usr/local/bin/cpu.sh system)
+echo "$SYSTEM"
+
+printf '#!/bin/sh\necho "%s"' "$SYSTEM" > /tmp/system
+chmod +x /tmp/system
+nc -lk -p 9999 -e /tmp/system &
+
+fortio server -ui-path ''

--- a/stress-ng/Dockerfile
+++ b/stress-ng/Dockerfile
@@ -9,13 +9,8 @@ RUN tar -xf V${STRESS_VER}.tar.gz && \
 	STATIC=1 make -j &&\
 	mv stress-ng /stress-ng/
 
-
-FROM alpine
+FROM benchmark-base
 MAINTAINER Kinvolk
-# dstat
-RUN apk add --update --no-cache py2-six
-COPY --from=dstat-builder /dstat/dstat /usr/local/bin
-COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
+
 # stress-ng
-RUN apk add --update --no-cache util-linux
 COPY --from=builder /stress-ng/stress-ng /sbin/

--- a/stress-ng/Dockerfile
+++ b/stress-ng/Dockerfile
@@ -14,3 +14,6 @@ MAINTAINER Kinvolk
 
 # stress-ng
 COPY --from=builder /stress-ng/stress-ng /sbin/
+
+# Runnable scripts
+COPY run-benchmark.sh /usr/local/bin/run-benchmark.sh

--- a/stress-ng/run-benchmark.sh
+++ b/stress-ng/run-benchmark.sh
@@ -1,0 +1,63 @@
+# This script has no hashbang as it's intended to run on systems with ash or
+# bash, including busybox.
+set -eu
+
+. /usr/local/bin/output.sh
+
+usage() {
+  cat <<EOF
+Usage: run-benchmark.sh [-h] [-v] [-y benchmark_type] [-t threads]
+                        $(output_options_short)
+
+Run the stress-ng benchmark
+
+Available options:
+
+-h, --help       Print this help and exit
+-v, --verbose    Print script debug info
+-y, --type       Type of stressor to run (spawn, hsearch, etc)
+-t, --threads    Amount of threads to use for the benchmark (default: 1)
+$(output_options_long)
+EOF
+  exit
+}
+
+parse_params() {
+  RESULT="bogo-ops/s"
+  TYPE=""
+  THREADS=1
+
+  parse_output_params "$@"
+  set -- $UNPARSED
+
+  while [ $# -gt 0 ]; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -v | --verbose) set -x ;;
+    -y | --type)
+      TYPE="${2-}"
+      shift
+      ;;
+    -t | --threads)
+      THREADS="${2-}"
+      shift
+      ;;
+    *) ;; # Skip unknown params
+    esac
+    shift
+  done
+}
+
+parse_params "$@"
+
+SYSTEM=$(/usr/local/bin/cpu.sh system)
+BENCHMARK_NAME="stress-ng $TYPE"
+PARAMS="threads=$THREADS"
+
+output_header
+
+cd /tmp
+for i in $(seq 1 $ITERATIONS); do
+  VALUE=$(stress-ng --$TYPE $THREADS --timeout 30s --metrics-brief 2>&1 | grep $TYPE | tail -n 1 | awk '{print $9}')
+  output_line "$VALUE"
+done

--- a/sysbench/Dockerfile
+++ b/sysbench/Dockerfile
@@ -11,13 +11,9 @@ RUN tar -xf ${SYSBENCH_VER}.tar.gz && \
 	make -j && \
 	make DESTDIR=/sysbench/sysbench-install-root/ install
 
-
-FROM alpine
+FROM benchmark-base
 MAINTAINER Kinvolk
-# dstat
-RUN apk add --update --no-cache py2-six
-COPY --from=dstat-builder /dstat/dstat /usr/local/bin
-COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
+
 # sysbench
-RUN apk add --update --no-cache util-linux so:libgcc_s.so.1 so:libmariadb.so.3 so:libaio.so.1
+RUN apk add --update --no-cache so:libgcc_s.so.1 so:libmariadb.so.3 so:libaio.so.1
 COPY --from=builder /sysbench/sysbench-install-root/ /

--- a/sysbench/Dockerfile
+++ b/sysbench/Dockerfile
@@ -17,3 +17,6 @@ MAINTAINER Kinvolk
 # sysbench
 RUN apk add --update --no-cache so:libgcc_s.so.1 so:libmariadb.so.3 so:libaio.so.1
 COPY --from=builder /sysbench/sysbench-install-root/ /
+
+# Runnable scripts
+COPY run-benchmark.sh /usr/local/bin/run-benchmark.sh

--- a/sysbench/run-benchmark.sh
+++ b/sysbench/run-benchmark.sh
@@ -1,0 +1,76 @@
+# This script has no hashbang as it's intended to run on systems with ash or
+# bash, including busybox.
+set -eu
+
+. /usr/local/bin/output.sh
+
+usage() {
+  cat <<EOF
+Usage: run-benchmark.sh [-h] [-v] [-y benchmark_type] [-t threads]
+                        $(output_options_short)
+
+Run the sysbench benchmark
+
+Available options:
+
+-h, --help       Print this help and exit
+-v, --verbose    Print script debug info
+-y, --type       Type of benchmark to run (mem, cpu, fileio)
+-t, --threads    Amount of threads to use for the benchmark (default: 1)
+$(output_options_long)
+EOF
+  exit
+}
+
+parse_params() {
+  TYPE=""
+  THREADS=1
+
+  parse_output_params "$@"
+  set -- $UNPARSED
+
+  while [ $# -gt 0 ]; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -v | --verbose) set -x ;;
+    -y | --type)
+      TYPE="${2-}"
+      shift
+      ;;
+    -t | --threads)
+      THREADS="${2-}"
+      shift
+      ;;
+    *) ;; # Skip unknown params
+    esac
+    shift
+  done
+}
+
+parse_params "$@"
+
+SYSTEM=$(/usr/local/bin/cpu.sh system)
+BENCHMARK_NAME="sysbench $TYPE"
+PARAMS="--threads=$THREADS"
+
+if [ "$TYPE" = "fileio" ]; then
+  PARAMS="$PARAMS --file-test-mode=rndwr"
+fi
+
+output_header
+
+cd /tmp
+for i in $(seq 1 $ITERATIONS); do
+  if [ "$TYPE" = "mem" ]; then
+    VALUE=$(sysbench $PARAMS --time=30 memory --memory-total-size=500G run | tee /dev/stderr | grep 'MiB/sec' | cut -d '(' -f 2 | cut -d ' ' -f 1)
+  elif [ "$TYPE" = "cpu" ]; then
+    VALUE=$(sysbench $PARAMS --time=30 cpu run | tee /dev/stderr | grep 'events per second' | cut -d : -f 2 | xargs)
+  elif [ "$TYPE" = "fileio" ]; then
+    sysbench fileio --file-test-mode=rndwr prepare
+    VALUE=$(sysbench $PARAMS --time=30 fileio run | tee /dev/stderr | grep 'written, MiB/s' | cut -d : -f 2 | xargs)
+  else
+    echo "ERROR: Unknown benchmark type"
+    exit 1
+  fi
+  output_line "$VALUE"
+done

--- a/wrk2-benchmark/Dockerfile
+++ b/wrk2-benchmark/Dockerfile
@@ -7,14 +7,9 @@ RUN unzip master.zip && \
     make -j && \
     strip wrk
 
-FROM alpine
+FROM benchmark-base
 MAINTAINER Kinvolk
-# dstat
-RUN apk add --update --no-cache py2-six
-COPY --from=dstat-builder /dstat/dstat /usr/local/bin
-COPY --from=dstat-builder /dstat/plugins /usr/local/bin/
-# lscpu
-RUN apk add --update --no-cache util-linux
+
 # wrk2
 RUN apk add --update --no-cache so:libcrypto.so.1.1 so:libssl.so.1.1 so:libgcc_s.so.1
 COPY --from=builder /usr/src/wrk2-master/wrk /usr/local/bin/

--- a/wrk2-benchmark/Dockerfile
+++ b/wrk2-benchmark/Dockerfile
@@ -14,3 +14,15 @@ MAINTAINER Kinvolk
 RUN apk add --update --no-cache so:libcrypto.so.1.1 so:libssl.so.1.1 so:libgcc_s.so.1
 COPY --from=builder /usr/src/wrk2-master/wrk /usr/local/bin/
 ADD body-100-report.lua /usr/local/share/wrk2/body-100-report.lua
+
+# nginx serving 404 on port 9000 running as benchmark user (switches if started as root)
+RUN apk add --update --no-cache nginx
+RUN adduser -u 1000 -D benchmark
+RUN sed -i 's/user nginx;/user benchmark;/g' /etc/nginx/nginx.conf
+RUN sed -i 's/80 default_server/9000 default_server/g' /etc/nginx/conf.d/default.conf
+RUN mkdir /run/nginx
+RUN chown benchmark:benchmark -R /var/lib/nginx /run/nginx/ /var/log/nginx
+
+# Runnable scripts
+COPY run-benchmark.sh /usr/local/bin/run-benchmark.sh
+COPY run-server.sh /usr/local/bin/run-server.sh

--- a/wrk2-benchmark/run-benchmark.sh
+++ b/wrk2-benchmark/run-benchmark.sh
@@ -1,0 +1,90 @@
+# This script has no hashbang as it's intended to run on systems with ash or
+# bash, including busybox.
+set -eu
+
+. /usr/local/bin/output.sh
+
+usage() {
+  cat <<EOF
+Usage: run-benchmark.sh [-h] [-v] [-T target_host] [-t threads] [-d duration]
+                        $(output_options_short)
+
+Run the wrk2 benchmark
+
+Available options:
+
+-h, --help       Print this help and exit
+-v, --verbose    Print script debug info
+-T, --target     Name of the host to target for the benchmark (default: wrk2-service)
+-t, --threads    Amount of threads and connections to use
+$(output_options_long)
+EOF
+  exit
+}
+
+parse_params() {
+  RESULT="p999 latency ms"
+  TARGET="wrk2-service"
+  THREADS=1
+  DURATION="60s"
+
+  parse_output_params "$@"
+  set -- $UNPARSED
+
+  while [ $# -gt 0 ]; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -v | --verbose) set -x ;;
+    -T | --target)
+      TARGET="${2-}"
+      shift
+      ;;
+    -t | --threads)
+      THREADS="${2-}"
+      shift
+      ;;
+    -d | --duration)
+      DURATION="${2-}"
+      shift
+      ;;
+    *) ;; # Skip unknown params
+    esac
+    shift
+  done
+}
+
+parse_params "$@"
+
+PORT=9000
+MODE=nginx
+
+while ! echo | nc "$TARGET" "$PORT"; do
+  echo "Waiting for $TARGET:$PORT..."
+  sleep 1
+done
+
+while ! echo | nc "$TARGET" 9999 > /tmp/system-out; do
+  sleep 1
+done
+
+SYSTEM="$(cat /tmp/system-out)"
+BENCHMARK_NAME="wrk2 $MODE"
+PARAMS="-d $DURATION -c $THREADS -t $THREADS (body 100B)"
+
+output_header
+
+for i in $(seq 1 $ITERATIONS); do
+  LATENCY="$(wrk -d $DURATION -c $THREADS -t $THREADS -R 2000 -L -s /usr/local/share/wrk2/body-100-report.lua "http://$TARGET:$PORT" | tee /dev/stderr | grep 99.900% | awk '{print $2}')"
+  # cut away unit (ms or s)
+  if echo "$LATENCY" | grep ms > /dev/null; then
+    U=m
+  else
+    U=s
+  fi
+  LATENCY="$(echo $LATENCY | cut -d "$U" -f 1)"
+  # calculate ms if unit was s
+  if [ "$U" = s ]; then
+    LATENCY="$(awk "BEGIN{print "$LATENCY"*1000}")"
+  fi
+  output_line "$LATENCY"
+done

--- a/wrk2-benchmark/run-server.sh
+++ b/wrk2-benchmark/run-server.sh
@@ -1,0 +1,10 @@
+set -eu
+
+SYSTEM=$(/usr/local/bin/cpu.sh system)
+echo "$SYSTEM"
+
+printf '#!/bin/sh\necho "%s"' "$SYSTEM" > /tmp/system
+chmod +x /tmp/system
+nc -lk -p 9999 -e /tmp/system &
+
+nginx -g "daemon off;"


### PR DESCRIPTION
# Refactor the benchmark containers to simplify usage

This change adds a `run-benchmark.sh` script to each of the container benchmarks to simplify how the benchmarks are invoked.

Each container benchmark includes a script with the same name, which receives the same base parameters, as well as a few parameters that are container specific. This way, they can be invoked either manually or from Kubernetes with a lot less logic.

The scripts use a base template of how parameters are parsed and received. They also rely on a common `output.sh` that takes care of handling the CSV parameters and generating the CSV output.

For containers that require a service to connect to, the service is also included in the container and can be invoked with `run-server.sh`.

# How to use / Testing done

Build the containers with `./build.sh`, then run one or more of the containers with `docker run -it <container>` and execute the `run-benchmark.sh` script. If a network connection is required, the service can be invoked with `run-server.sh &` and then the benchmark can be run with `run-benchmark -T localhost`.

This was done for all the containers invoked from the `cluster-script` directory (stress-ng sysbench iperf3 memtier ab fortio wrk2-benchmark). The fio and perf container are not used by that script, so they were ignored. The nginx container was being used to deploy a separate nginx service, but is now shipped inside the wrk2 and ab containers, to make each benchmark completely self-contained.

# Future work

This is just a start of a cleanup for this repository. As future work not in scope for this PR:
- The generation of the Kubernetes jobs should be adapted to take into account the changes included here.
- The output generation should be customized to generate prometheus metrics instead of CSV.
- Improve documentation