### PR TITLE
mysql helm: Parameterise namespace field

### DIFF
--- a/mysql/helm/templates/benchmark-job.yaml
+++ b/mysql/helm/templates/benchmark-job.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: run-mysql-benchmark
-  namespace: mysql
+  namespace: {{.Release.Namespace}}
 spec:
   template:
     spec:

--- a/mysql/helm/templates/rbac.yaml
+++ b/mysql/helm/templates/rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: mysql:mysql:priviledged
-  namespace: mysql
+  namespace: {{.Release.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: mysql
-  namespace: mysql
+  namespace: {{.Release.Namespace}}

--- a/mysql/helm/templates/serviceaccount.yaml
+++ b/mysql/helm/templates/serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: mysql
-  namespace: mysql
+  namespace: {{.Release.Namespace}}


### PR DESCRIPTION
Right now the configs have hardcoded `namespace: mysql`, this commit
changes that.

