### PR TITLE
Memtier benchmarks: benchmark changes + dashboard

### DIFF
--- a/memtier/dashboards/memcached-benchmark.json
+++ b/memtier/dashboards/memcached-benchmark.json
@@ -1,0 +1,736 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 28,
+  "iteration": 1620305624847,
+  "links": [],
+  "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "memtier_run_information_threads{cloud=\"$cloud\", exported_instance=\"$instance\", run=\"$run\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "General Statistics - Threads",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 46,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "memtier_run_information_connections_per_thread{cloud=\"$cloud\", exported_instance=\"$instance\", run=\"$run\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "General Statistics - Connections per Thread",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 47,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "memtier_run_information_seconds{cloud=\"$cloud\", exported_instance=\"$instance\", run=\"$run\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "General Statistics - Seconds",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "memtier_all_stats_totals_ops_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "format": "time_series",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Ops/s",
+          "refId": "E"
+        },
+        {
+          "expr": "memtier_all_stats_totals_hits_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Hits/s",
+          "refId": "C"
+        },
+        {
+          "expr": "memtier_all_stats_totals_kb_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Kb/s",
+          "refId": "B"
+        },
+        {
+          "expr": "memtier_all_stats_totals_misses_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Misses/s",
+          "refId": "A"
+        },
+        {
+          "expr": "memtier_all_stats_totals_latency{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Latency",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Totals",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 40,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "memtier_all_stats_waits_ops_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Ops/s",
+          "refId": "E"
+        },
+        {
+          "expr": "memtier_all_stats_waits_hits_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Hits/s",
+          "refId": "C"
+        },
+        {
+          "expr": "memtier_all_stats_waits_kb_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Kb/s",
+          "refId": "B"
+        },
+        {
+          "expr": "memtier_all_stats_waits_misses_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Misses/s",
+          "refId": "A"
+        },
+        {
+          "expr": "memtier_all_stats_waits_latency{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Latency",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Waits",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 41,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "memtier_all_stats_gets_ops_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Ops/s",
+          "refId": "E"
+        },
+        {
+          "expr": "memtier_all_stats_gets_hits_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Hits/s",
+          "refId": "C"
+        },
+        {
+          "expr": "memtier_all_stats_gets_kb_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Kb/s",
+          "refId": "B"
+        },
+        {
+          "expr": "memtier_all_stats_gets_misses_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Misses/s",
+          "refId": "A"
+        },
+        {
+          "expr": "memtier_all_stats_gets_latency{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Latency",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Gets",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 42,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "memtier_all_stats_sets_ops_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Ops/s",
+          "refId": "E"
+        },
+        {
+          "expr": "memtier_all_stats_sets_hits_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Hits/s",
+          "refId": "C"
+        },
+        {
+          "expr": "memtier_all_stats_sets_kb_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Kb/s",
+          "refId": "B"
+        },
+        {
+          "expr": "memtier_all_stats_sets_misses_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Misses/s",
+          "refId": "A"
+        },
+        {
+          "expr": "memtier_all_stats_sets_latency{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Latency",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Sets",
+      "type": "gauge"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": null,
+        "definition": "label_values(memtier_run_information_seconds{exported_job=\"memtier_memcached\"},cloud)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "cloud",
+        "options": [],
+        "query": {
+          "query": "label_values(memtier_run_information_seconds{exported_job=\"memtier_memcached\"},cloud)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
+        "datasource": null,
+        "definition": "label_values(memtier_run_information_seconds{exported_job=\"memtier_memcached\",cloud=\"$cloud\"}, cluster)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "cluster",
+        "options": [
+          {
+            "isNone": true,
+            "selected": true,
+            "text": "None",
+            "value": ""
+          }
+        ],
+        "query": {
+          "query": "label_values(memtier_run_information_seconds{exported_job=\"memtier_memcached\",cloud=\"$cloud\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": null,
+        "definition": "label_values(memtier_run_information_seconds{exported_job=\"memtier_memcached\",cloud=\"$cloud\",cluster=\"$cluster\"},exported_instance)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(memtier_run_information_seconds{exported_job=\"memtier_memcached\",cloud=\"$cloud\",cluster=\"$cluster\"},exported_instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": null,
+        "definition": "label_values(memtier_run_information_seconds{exported_job=\"memtier_memcached\",cloud=\"$cloud\",cluster=\"$cluster\",exported_instance=\"$instance\",exported_job=\"memtier_memcached\"},run)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "run",
+        "options": [],
+        "query": {
+          "query": "label_values(memtier_run_information_seconds{exported_job=\"memtier_memcached\",cloud=\"$cloud\",cluster=\"$cluster\",exported_instance=\"$instance\",exported_job=\"memtier_memcached\"},run)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Memtier Memcached Benchmark",
+  "uid": "uLqqxgjGk",
+  "version": 10
+}

--- a/memtier/dashboards/redis-benchmark.json
+++ b/memtier/dashboards/redis-benchmark.json
@@ -1,0 +1,740 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 29,
+  "iteration": 1620305894098,
+  "links": [],
+  "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sum(memtier_run_information_threads{cloud=\"$cloud\", exported_instance=\"$instance\", run=\"$run\"})",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "General Statistics - Threads",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 46,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "avg(memtier_run_information_connections_per_thread{cloud=\"$cloud\", exported_instance=\"$instance\", run=\"$run\"})",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "General Statistics - Connections per Thread",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 47,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "max(memtier_run_information_seconds{cloud=\"$cloud\", exported_instance=\"$instance\", run=\"$run\"})  ",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "General Statistics - Seconds",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sum(memtier_all_stats_totals_ops_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "format": "time_series",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Ops/s",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(memtier_all_stats_totals_hits_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Hits/s",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(memtier_all_stats_totals_kb_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Kb/s",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(memtier_all_stats_totals_misses_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Misses/s",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(memtier_all_stats_totals_latency{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Latency",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Totals",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 40,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sum(memtier_all_stats_waits_ops_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Ops/s",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(memtier_all_stats_waits_hits_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Hits/s",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(memtier_all_stats_waits_kb_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Kb/s",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(memtier_all_stats_waits_misses_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Misses/s",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(memtier_all_stats_waits_latency{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Latency",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Waits",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 41,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sum(memtier_all_stats_gets_ops_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Ops/s",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(memtier_all_stats_gets_hits_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Hits/s",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(memtier_all_stats_gets_kb_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Kb/s",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(memtier_all_stats_gets_misses_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Misses/s",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(memtier_all_stats_gets_latency{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Latency",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Gets",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 42,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sum(memtier_all_stats_sets_ops_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Ops/s",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(memtier_all_stats_sets_hits_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Hits/s",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(memtier_all_stats_sets_kb_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Kb/s",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(memtier_all_stats_sets_misses_sec{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Misses/s",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(memtier_all_stats_sets_latency{cloud=\"$cloud\", cluster=\"$cluster\", exported_instance=\"$instance\", run=\"$run\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Latency",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Sets",
+      "type": "gauge"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": null,
+        "definition": "label_values(memtier_run_information_seconds{exported_job=\"memtier_redis\"},cloud)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "cloud",
+        "options": [],
+        "query": {
+          "query": "label_values(memtier_run_information_seconds{exported_job=\"memtier_redis\"},cloud)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
+        "datasource": null,
+        "definition": "label_values(memtier_run_information_seconds{exported_job=\"memtier_redis\",cloud=\"$cloud\"}, cluster)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "cluster",
+        "options": [
+          {
+            "isNone": true,
+            "selected": true,
+            "text": "None",
+            "value": ""
+          }
+        ],
+        "query": {
+          "query": "label_values(memtier_run_information_seconds{exported_job=\"memtier_redis\",cloud=\"$cloud\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": null,
+        "definition": "label_values(memtier_run_information_seconds{exported_job=\"memtier_redis\",cloud=\"$cloud\",cluster=\"$cluster\"},exported_instance)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(memtier_run_information_seconds{exported_job=\"memtier_redis\",cloud=\"$cloud\",cluster=\"$cluster\"},exported_instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": null,
+        "definition": "label_values(memtier_run_information_seconds{exported_job=\"memtier_redis\",cloud=\"$cloud\",cluster=\"$cluster\",exported_instance=\"$instance\"},run)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "run",
+        "options": [],
+        "query": {
+          "query": "label_values(memtier_run_information_seconds{exported_job=\"memtier_redis\",cloud=\"$cloud\",cluster=\"$cluster\",exported_instance=\"$instance\"},run)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Memtier Redis Benchmark",
+  "uid": "_nfDDWjGk",
+  "version": 9
+}

--- a/memtier/helm/templates/benchmark-job.yaml
+++ b/memtier/helm/templates/benchmark-job.yaml
@@ -14,26 +14,23 @@ spec:
       - name: run-memtier-benchmark
         image: quay.io/kinvolk/benchmark-memtier
         imagePullPolicy: Always
-        env:
-        - name: MEMTIER_TYPE
-          value: "{{ .Values.type }}"
-        - name: MEMTIER_THREADS
-          value: "{{ .Values.threads }}"
-        - name: MEMTIER_ITERATIONS
-          value: "{{ .Values.iterations }}"
-        - name: PUSHGATEWAY_URL
-          value: "{{ .Values.pushgatewayURL }}"
-        - name: CLOUD
-          value: "{{ .Values.cloud }}"
-        - name: INSTANCE
-          value: "{{ .Values.instance }}"
-        - name: JOBNAME
-          value: "{{ .Values.jobname }}"
         command:
-        - sh
-        args:
-        - -c
         - /usr/local/bin/run-benchmark.sh
+        args:
+        - --type
+        - "{{ .Values.type }}"
+        - --threads
+        - "{{ .Values.threads }}"
+        - --iterations
+        - "{{ .Values.iterations }}"
+        - --push-gateway
+        - "{{ .Values.pushgatewayURL }}"
+        - --cloud
+        - "{{ .Values.cloud }}"
+        - --instance
+        - "{{ .Values.instance }}"
+        - --job-name
+        - "{{ .Values.jobname }}"
       automountServiceAccountToken: false
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/memtier/helm/values.yaml
+++ b/memtier/helm/values.yaml
@@ -1,6 +1,6 @@
-threads: 1
-type: memcached
-iterations: 1
+threads: 1;4;8;16
+type: memcached;redis
+iterations: 5
 pushgatewayURL: http://pushgateway.monitoring:9091
 cloud: em
 instance: instancetype

--- a/memtier/run-benchmark.sh
+++ b/memtier/run-benchmark.sh
@@ -14,8 +14,8 @@ Available options:
 
 -h, --help       Print this help and exit
 -v, --verbose    Print script debug info
--y, --type       Type of benchmark to run (memcached, redis)
--t, --threads    Amount of threads to use for the benchmark (default: 1)
+-y, --type       Type of benchmark to run (memcached, redis). Optionally a semicolon separated list.
+-t, --threads    Amount of threads to use for the benchmark (default: 1). Optionally a semicolon separated list.
 $(output_options_long)
 EOF
   exit
@@ -34,11 +34,11 @@ parse_params() {
     -h | --help) usage ;;
     -v | --verbose) set -x ;;
     -y | --type)
-      TYPE="${2-}"
+      ARG_TYPE="${2-}"
       shift
       ;;
     -t | --threads)
-      THREADS="${2-}"
+      ARG_THREADS="${2-}"
       shift
       ;;
     *) ;; # Skip unknown params
@@ -49,81 +49,98 @@ parse_params() {
 
 parse_params "$@"
 
+start_server() {
+  if [ "$TYPE" = "memcached" ]; then
+    # When benchmarking memcached, use half as many more threads as those being
+    # used by the server.
+    BENCHMARKTHREADS=$(($THREADS+$THREADS/2))
+    BENCHMARKPROCESSES=1
+    CONCURRENCYTYPE=threads
+    PROTOCOL=memcache_binary
+    memcached --port "$(( PORT + 1 ))" -u "$(whoami)" -t "$THREADS" &
+  else
+    BENCHMARKTHREADS=1
+    BENCHMARKPROCESSES="$THREADS"
+    CONCURRENCYTYPE=processes
+    PROTOCOL=redis
+    for P in $(seq 1 $BENCHMARKPROCESSES); do
+      redis-server --port "$(( PORT + P ))" &
+    done
+  fi
+  
+  echo "Using $THREADS $CONCURRENCYTYPE for the database"
+  for P in $(seq 1 $BENCHMARKPROCESSES); do
+    while [ "$(wget "http://127.0.0.1:$(( PORT + P ))" 2>&1 | grep "Connection refused")" != "" ]; do
+      sleep 1
+      echo "Waiting for DB $P to start..."
+    done
+  done
+}
+
+benchmark() {
+  SYSTEM=$(/usr/local/bin/cpu.sh system)
+  BENCHMARK_NAME="memtier_$TYPE"
+  PARAMS="$CONCURRENCYTYPE=$THREADS"
+  output_header
+
+  echo "Using $BENCHMARKPROCESSES processes and $BENCHMARKTHREADS threads for the benchmark client"
+  for I in $(seq 1 $ITERATIONS); do
+    WAIT=""
+    for P in $(seq 1 $BENCHMARKPROCESSES); do
+      { memtier_benchmark -p "$(( PORT + P ))" -P "$PROTOCOL" -t "$BENCHMARKTHREADS" --test-time 30 --pipeline=100 --ratio 1:1 -c 25 -x 1 --data-size-range=10240-1048576 --key-pattern S:S --json-out-file=$I-$P.json 2>&1 | tee /dev/stderr | grep Totals | tail -n 1 | awk '{print $2}' | cut -d . -f 1 > "$P" ; } &
+      WAIT="$WAIT""$! "
+    done
+    wait $WAIT
+    SUM=0
+    for P in $(cat $(seq 1 $BENCHMARKPROCESSES)); do
+      SUM="$(( SUM + P ))"
+    done
+    # Pushing metrics to pushgateway.
+    TS=$(date -Iseconds | sed -e 's/T/__/' -e 's/+.*//')
+    for P in $(seq 1 $BENCHMARKPROCESSES); do
+      RUN_ID="$TS/process/$P"
+      read -d '' metrics <<EOF || true
+          # TYPE memtier_run_information_ gauge
+          $(cat /tmp/$I-$P.json | jq -r '."run information" | to_entries | .[] | "memtier_run_information_"+ (.key|ascii_downcase|gsub("\\s";"_")) + " " + (.value|tostring)')
+
+          # TYPE memtier_all_stats_sets_ gauge
+          $(cat /tmp/$I-$P.json | jq -r '."ALL STATS".Sets | to_entries | .[] | "memtier_all_stats_sets_"+ (.key|ascii_downcase|gsub("/";"_")) + " " + (.value|tostring)')
+
+          # TYPE memtier_all_stats_gets_ gauge
+          $(cat /tmp/$I-$P.json | jq -r '."ALL STATS".Gets | to_entries | .[] | "memtier_all_stats_gets_"+ (.key|ascii_downcase|gsub("/";"_")) + " " + (.value|tostring)')
+
+          # TYPE memtier_all_stats_waits_ gauge
+          $(cat /tmp/$I-$P.json | jq -r '."ALL STATS".Waits | to_entries | .[] | "memtier_all_stats_waits_"+ (.key|ascii_downcase|gsub("/";"_")) + " " + (.value|tostring)')
+
+          # TYPE memtier_all_stats_totals_ gauge
+          $(cat /tmp/$I-$P.json | jq -r '."ALL STATS".Totals | to_entries | .[] | "memtier_all_stats_totals_"+ (.key|ascii_downcase|gsub("/";"_")) + " " + (.value|tostring)')
+
+          # TYPE memtier_request_latency_distribution_set gauge
+          $(cat /tmp/$I-$P.json | jq -r '."ALL STATS".SET | .[] | "memtier_request_latency_distribution_set{msec=" + "\"" + (."<=msec"|tostring) + "\"" + "}" + " " + (.percent|tostring)')
+
+          # TYPE memtier_request_latency_distribution_get gauge
+          $(cat /tmp/$I-$P.json | jq -r '."ALL STATS".GET | .[] | "memtier_request_latency_distribution_get{msec=" + "\"" + (."<=msec"|tostring) + "\"" + "}" + " " + (.percent|tostring)')
+EOF
+      push_metrics "$metrics"
+    done
+    output_line "$SUM"
+  done
+}
+
+cleanup() {
+  killall redis-server memcached || true
+  sleep 5 # Wait for the servers to actually finish
+}
+
 cd /tmp
 PORT=7000
 
-if [ "$TYPE" = "memcached" ]; then
-  # When benchmarking memcached, use half as many more threads as those being
-  # used by the server.
-  BENCHMARKTHREADS=$(($THREADS+$THREADS/2))
-  BENCHMARKPROCESSES=1
-  CONCURRENCYTYPE=threads
-  PROTOCOL=memcache_binary
-  memcached --port "$(( PORT + 1 ))" -u "$(whoami)" -t "$THREADS" &
-else
-  BENCHMARKTHREADS=1
-  BENCHMARKPROCESSES="$THREADS"
-  CONCURRENCYTYPE=processes
-  PROTOCOL=redis
-  for P in $(seq 1 $BENCHMARKPROCESSES); do
-    redis-server --port "$(( PORT + P ))" &
-  done
-fi
-
-echo "Using $THREADS $CONCURRENCYTYPE for the database"
-for P in $(seq 1 $BENCHMARKPROCESSES); do
-  while [ "$(wget "http://127.0.0.1:$(( PORT + P ))" 2>&1 | grep "Connection refused")" != "" ]; do
-    sleep 1
-    echo "Waiting for DB $P to start..."
+for TYPE in ${ARG_TYPE//;/ } ; do
+  echo "Running for type ${TYPE}"
+  for THREADS in ${ARG_THREADS//;/ }; do
+    echo "Running for threads ${THREADS}"
+    start_server
+    benchmark
+    cleanup
   done
 done
-
-SYSTEM=$(/usr/local/bin/cpu.sh system)
-BENCHMARK_NAME="memtier_$TYPE"
-PARAMS="$CONCURRENCYTYPE=$THREADS"
-output_header
-
-echo "Using $BENCHMARKPROCESSES processes and $BENCHMARKTHREADS threads for the benchmark client"
-for I in $(seq 1 $ITERATIONS); do
-  WAIT=""
-  for P in $(seq 1 $BENCHMARKPROCESSES); do
-    { memtier_benchmark -p "$(( PORT + P ))" -P "$PROTOCOL" -t "$BENCHMARKTHREADS" --test-time 30 --pipeline=100 --ratio 1:1 -c 25 -x 1 --data-size-range=10240-1048576 --key-pattern S:S --json-out-file=$I-$P.json 2>&1 | tee /dev/stderr | grep Totals | tail -n 1 | awk '{print $2}' | cut -d . -f 1 > "$P" ; } &
-    WAIT="$WAIT""$! "
-  done
-  wait $WAIT
-  SUM=0
-  for P in $(cat $(seq 1 $BENCHMARKPROCESSES)); do
-    SUM="$(( SUM + P ))"
-  done
-  # Pushing metrics to pushgateway.
-  TS=$(date -Iseconds | sed -e 's/T/__/' -e 's/+.*//')
-  for P in $(seq 1 $BENCHMARKPROCESSES); do
-    RUN_ID="$TS/process/$P"
-    read -d '' metrics <<EOF || true
-        # TYPE memtier_run_information_ gauge
-        $(cat /tmp/$I-$P.json | jq -r '."run information" | to_entries | .[] | "memtier_run_information_"+ (.key|ascii_downcase|gsub("\\s";"_")) + " " + (.value|tostring)')
-
-        # TYPE memtier_all_stats_sets_ gauge
-        $(cat /tmp/$I-$P.json | jq -r '."ALL STATS".Sets | to_entries | .[] | "memtier_all_stats_sets_"+ (.key|ascii_downcase|gsub("/";"_")) + " " + (.value|tostring)')
-
-        # TYPE memtier_all_stats_gets_ gauge
-        $(cat /tmp/$I-$P.json | jq -r '."ALL STATS".Gets | to_entries | .[] | "memtier_all_stats_gets_"+ (.key|ascii_downcase|gsub("/";"_")) + " " + (.value|tostring)')
-
-        # TYPE memtier_all_stats_waits_ gauge
-        $(cat /tmp/$I-$P.json | jq -r '."ALL STATS".Waits | to_entries | .[] | "memtier_all_stats_waits_"+ (.key|ascii_downcase|gsub("/";"_")) + " " + (.value|tostring)')
-
-        # TYPE memtier_all_stats_totals_ gauge
-        $(cat /tmp/$I-$P.json | jq -r '."ALL STATS".Totals | to_entries | .[] | "memtier_all_stats_totals_"+ (.key|ascii_downcase|gsub("/";"_")) + " " + (.value|tostring)')
-
-        # TYPE memtier_request_latency_distribution_set gauge
-        $(cat /tmp/$I-$P.json | jq -r '."ALL STATS".SET | .[] | "memtier_request_latency_distribution_set{msec=" + "\"" + (."<=msec"|tostring) + "\"" + "}" + " " + (.percent|tostring)')
-
-        # TYPE memtier_request_latency_distribution_get gauge
-        $(cat /tmp/$I-$P.json | jq -r '."ALL STATS".GET | .[] | "memtier_request_latency_distribution_get{msec=" + "\"" + (."<=msec"|tostring) + "\"" + "}" + " " + (.percent|tostring)')
-EOF
-    push_metrics "$metrics"
-  done
-  output_line "$SUM"
-done
-
-killall redis-server memcached || true


### PR DESCRIPTION
# Some small changes to the memtier benchmarks plus a grafana dashboard

This PR includes some changes to the memtier benchmarks:

- Use half as many benchmarking threads than serving threads when benchmarking memcached
- Use a pipeline of 100 threads
- Use only parameters and no environment variables with the helm chart
- Use the benchmark job name calculated inside the script (that includes whether this is redis or memcached) for the job name used when pushing metrics (the one sent by helm is not used)
- Add a push_metrics function to output.sh, and use that

It also includes two grafana dashboards, one for redis and one for memcached