### PR TITLE
emojivoto: use custom metrics-merger jobs

### DIFF
--- a/emojivoto-benchmark/helm/metrics-merger/templates/metrics-merger.yaml
+++ b/emojivoto-benchmark/helm/metrics-merger/templates/metrics-merger.yaml
@@ -27,3 +27,4 @@ spec:
         args:
         - {{ .Values.prometheusServiceUrl }}
         - {{ .Values.pushgatewayURL }}
+        - {{ .Values.exportedJobs }}

--- a/emojivoto-benchmark/helm/metrics-merger/values.yaml
+++ b/emojivoto-benchmark/helm/metrics-merger/values.yaml
@@ -1,2 +1,3 @@
 prometheusServiceUrl: "http://prometheus-operator-kube-p-prometheus.monitoring:9090"
 pushgatewayURL: "pushgateway.monitoring:9091"
+exportedJobs: "Intel,AMD,Graviton,AmpereA1"


### PR DESCRIPTION
This change leverages the metrics-merger feature of setting custom merge
jobs in order to merge results from Intel, AMD, Graviton, and Ampere
CPUs.

The metrics-merger feature was introduced with
f438e26fcba7cfa49e68bf963d2f778d50c5a6d7.

This PR requires https://github.com/kinvolk/service-mesh-benchmark/pull/72 (and a respectively updated metrics-merger container image).